### PR TITLE
Device switch

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -5,8 +5,15 @@ const source =  'let xrconfiguration;'
 +   'const _Math = (' + MathInjection + ')();'
 +   'const Controller = (' + ControllerInjection + ')();'
 +   'const Headset = (' + HeadsetInjection + ')();'
++   'const controller = new Controller();'
++   'const headset = new Headset();'
 +   '(' + WebXRPolyfillInjection + ')();'
 +   'xrconfiguration = new Configuration();'
++   'xrconfiguration.addEventListener(\'devicechange\', event => {'
++     'const deviceType = event.configuration.deviceType;'
++     'headset.setDeviceType(deviceType);'
++     'controller.setDeviceType(deviceType);'
++   '});'
 +   'console.log(this);'
 + '})();';
 const script = document.createElement('script');
@@ -18,12 +25,12 @@ const configurationId = 'webxr-extension';
 const initialValue = '0';
 
 browser.storage.local.get(configurationId).then(result => {
-  const [headsetType] = (result[configurationId] || initialValue).split(':');
+  const [deviceType] = (result[configurationId] || initialValue).split(':');
   const script2 = document.createElement('script');
   const source2 = ''
   + '(function() {'
   +   'const Configuration = xrconfiguration.constructor;'
-  +   'xrconfiguration.setHeadsetType(' + headsetType + ');'
+  +   'xrconfiguration.setDeviceType(' + deviceType + ');'
   +   'console.log(xrconfiguration);'
   + '})();';
   script2.textContent = source2;

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1,16 +1,18 @@
 ﻿function ConfigurationInjection() {
   'use strict';
 
-  class Configuration {
+  class Configuration extends EventDispatcher {
     constructor() {
-      this.headsetType = null;
+      super();
+      this.deviceType = Configuration.deviceTypes().None;
     }
 
-    setHeadsetType(type) {
-      this.headsetType = type;
+    setDeviceType(type) {
+      this.deviceType = type;
+      this.dispatchEvent('devicechange', {type: 'devicechange', configuration: this});
     }
 
-    static headsetTypes() {
+    static deviceTypes() {
       return {
         None: 0,
         OculusGo: 1,

--- a/src/controller.js
+++ b/src/controller.js
@@ -3,16 +3,34 @@ function ControllerInjection() {
 
   //
 
+  const deviceTypes = Configuration.deviceTypes();
+
+  const capabilities = {};
+  capabilities[deviceTypes.None] = {position: false, rotation: false};
+  capabilities[deviceTypes.OculusGo] = {position: false, rotation: true};
+  capabilities[deviceTypes.OculusQuest] = {position: true, rotation: true};
+
+  const ids = {};
+  ids[deviceTypes.None] = 'None';
+  ids[deviceTypes.OculusGo] = 'Oculus Go Controller';
+  ids[deviceTypes.OculusQuest] = 'Oculus Quest Controller';
+
   class Controller {
     constructor() {
       this.session = null;
+      this._deviceType = deviceTypes.None;
 
       this._keys = {
-        trigger: 32,   // space
-        turnLeft: 37,  // left
-        turnUp: 38,    // up
-        turnRight: 39, // right
-        turnDown: 40   // down
+        enable: 16,       // shift
+        trigger: 32,      // space
+        moveLeft: 65,     // a
+        moveRight: 68,    // d
+        moveDown: 83,     // s
+        moveUp: 87,       // w
+        turnUp: 73,       // i
+        turnLeft: 74,     // j
+        turnDown: 75,     // k
+        turnRight: 76     // l
       };
 
       this._keyPressed = {};
@@ -22,7 +40,7 @@ function ControllerInjection() {
       }
 
       this._gamepad = {
-        id: 'Oculus Go Controller',
+        id: ids[this._deviceType],
         pose: {
           hasPosition: true,
           position: [0, 0, 0],
@@ -70,6 +88,11 @@ function ControllerInjection() {
       this.session = session;
     }
 
+    setDeviceType(type) {
+      this._deviceType = type;
+      this._gamepad.id = ids[type];
+    }
+
     _update() {
       const keys = this._keys;
       const keyPressed = this._keyPressed;
@@ -79,6 +102,7 @@ function ControllerInjection() {
       const quaternion = this._quaternion;
       const scale = this._scale;
       const matrix = this._matrix;
+      const capability = capabilities[this._deviceType];
 
       if (keyPressed[keys.trigger] && !gamepad.buttons[1].pressed) {
         gamepad.buttons[1].pressed = true;
@@ -94,17 +118,34 @@ function ControllerInjection() {
         }
       }
 
-      if(keyPressed[keys.turnLeft]) {
-        rotation.y += 0.02;
+      if (capability.position && keyPressed[keys.enable]) {
+        if (keyPressed[keys.moveLeft]) {
+          position.x -= 0.02;
+        }
+        if (keyPressed[keys.moveRight]) {
+          position.x += 0.02;
+        }
+        if (keyPressed[keys.moveUp]) {
+          position.y += 0.02;
+        }
+        if (keyPressed[keys.moveDown]) {
+          position.y -= 0.02;
+        }
       }
-      if(keyPressed[keys.turnRight]) {
-        rotation.y -= 0.02;
-      }
-      if(keyPressed[keys.turnUp]) {
-        rotation.x += 0.02;
-      }
-      if(keyPressed[keys.turnDown]) {
-        rotation.x -= 0.02;
+
+      if (capability.rotation && keyPressed[keys.enable]) {
+        if (keyPressed[keys.turnLeft]) {
+          rotation.y += 0.02;
+        }
+        if (keyPressed[keys.turnRight]) {
+          rotation.y -= 0.02;
+        }
+        if (keyPressed[keys.turnUp]) {
+          rotation.x += 0.02;
+        }
+        if (keyPressed[keys.turnDown]) {
+          rotation.x -= 0.02;
+        }
       }
 
       quaternion.fromEuler(rotation);

--- a/src/event-dispatcher.js
+++ b/src/event-dispatcher.js
@@ -10,9 +10,11 @@
       if (this.listeners[key] === undefined) {
         this.listeners[key] = [];
       }
+
       if (this.listeners[key].indexOf(func) >= 0) {
         return;
       }
+
       this.listeners[key].push(func);
     }
 

--- a/src/headset.js
+++ b/src/headset.js
@@ -2,12 +2,20 @@ function HeadsetInjection() {
   'use strict';
 
   const tmpVector3 = new _Math.Vector3();
+  const deviceTypes = Configuration.deviceTypes();
+
+  const capabilities = {};
+  capabilities[deviceTypes.None] = {position: false, rotation: false};
+  capabilities[deviceTypes.OculusGo] = {position: false, rotation: true};
+  capabilities[deviceTypes.OculusQuest] = {position: true, rotation: true};
 
   class Headset {
     constructor() {
       this.session = null;
+      this._deviceType = deviceTypes.None;
 
       this._keys = {
+        disable: 16,      // shift
         moveLeft: 65,     // a
         moveRight: 68,    // d
         moveBackward: 83, // s
@@ -82,6 +90,10 @@ function HeadsetInjection() {
       }
     }
 
+    setDeviceType(type) {
+      this._deviceType = type;
+    }
+
     _updateHeadset() {
       const keys = this._keys;
       const keyPressed = this._keyPressed;
@@ -91,44 +103,48 @@ function HeadsetInjection() {
       const scale = this._scale;
       const matrix = this._matrix;
       const matrixInverse = this._matrixInverse;
+      const capability = capabilities[this._deviceType];
 
       matrix.getDirection(tmpVector3);
 
-      if (keyPressed[keys.moveLeft]) {
-        position.x -= tmpVector3.z * 0.02;
-        position.y -= tmpVector3.y * 0.02;
-        position.z += tmpVector3.x * 0.02;
-      }
-      if (keyPressed[keys.moveRight]) {
-        position.x += tmpVector3.z * 0.02;
-        position.y += tmpVector3.y * 0.02;
-        position.z -= tmpVector3.x * 0.02;
-      }
-      if (keyPressed[keys.moveForward]) {
-        position.x -= tmpVector3.x * 0.02;
-        position.y -= tmpVector3.y * 0.02;
-        position.z -= tmpVector3.z * 0.02;
-      }
-      if (keyPressed[keys.moveBackward]) {
-        position.x += tmpVector3.x * 0.02;
-        position.y += tmpVector3.y * 0.02;
-        position.z += tmpVector3.z * 0.02;
-      }
-
-      if (keyPressed[keys.turnLeft]) {
-        rotation.y += 0.02;
-      }
-      if (keyPressed[keys.turnRight]) {
-        rotation.y -= 0.02;
-      }
-      if (keyPressed[keys.turnUp]) {
-        rotation.x += 0.02;
-      }
-      if (keyPressed[keys.turnDown]) {
-        rotation.x -= 0.02;
+      if (capability.position && !keyPressed[keys.disable]) {
+        if (keyPressed[keys.moveLeft]) {
+          position.x -= tmpVector3.z * 0.02;
+          position.y -= tmpVector3.y * 0.02;
+          position.z += tmpVector3.x * 0.02;
+        }
+        if (keyPressed[keys.moveRight]) {
+          position.x += tmpVector3.z * 0.02;
+          position.y += tmpVector3.y * 0.02;
+          position.z -= tmpVector3.x * 0.02;
+        }
+        if (keyPressed[keys.moveForward]) {
+          position.x -= tmpVector3.x * 0.02;
+          position.y -= tmpVector3.y * 0.02;
+          position.z -= tmpVector3.z * 0.02;
+        }
+        if (keyPressed[keys.moveBackward]) {
+          position.x += tmpVector3.x * 0.02;
+          position.y += tmpVector3.y * 0.02;
+          position.z += tmpVector3.z * 0.02;
+        }
       }
 
-      quaternion.fromEuler(rotation);
+      if (capability.rotation && !keyPressed[keys.disable]) {
+        if (keyPressed[keys.turnLeft]) {
+          rotation.y += 0.02;
+        }
+        if (keyPressed[keys.turnRight]) {
+          rotation.y -= 0.02;
+        }
+        if (keyPressed[keys.turnUp]) {
+          rotation.x += 0.02;
+        }
+        if (keyPressed[keys.turnDown]) {
+          rotation.x -= 0.02;
+        }
+        quaternion.fromEuler(rotation);
+      }
 
       position.x -= 0.2;
 

--- a/src/webxr-polyfill.js
+++ b/src/webxr-polyfill.js
@@ -1,11 +1,6 @@
 function WebXRPolyfillInjection() {
   'use strict';
 
-  //
-
-  const controller = new Controller();
-  const headset = new Headset();
-
   // https://www.w3.org/TR/webxr/#xr-interface
 
   class XR {


### PR DESCRIPTION
User can switch device emulator in popup page. Currently it just switches degrees of freedom.

![image](https://user-images.githubusercontent.com/7637832/59561405-e120f280-905a-11e9-87f5-37587611bd64.png)

Also change UI. WASD for position, IJKL for rotation. With shift controller, without shift headset.
