### PR TITLE
Chrome compatible storage

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,7 +4,7 @@ const initialValues = '1:0'.split(':'); // @TODO: Import from Configuration
 const deviceSelect = document.getElementById('deviceSelect');
 const stereoSelect = document.getElementById('stereoSelect');
 
-browser.storage.local.get(configurationId).then(result => {
+chrome.storage.local.get(configurationId, result => {
   const values = (result[configurationId] || '').split(':');
   let deviceIndex = parseInt(values[0]);
   let stereoIndex = parseInt(values[1]);
@@ -30,7 +30,7 @@ function storeValues() {
     deviceSelect.selectedIndex,
     stereoSelect.selectedIndex
   ].join(':');
-  browser.storage.local.set(storedValue).then(() => {
+  chrome.storage.local.set(storedValue, () => {
     // window.alert(window); // to check if works
   });
 }

--- a/content-script.js
+++ b/content-script.js
@@ -24,7 +24,7 @@ script.parentNode.removeChild(script);
 
 const configurationId = 'webxr-extension';
 
-browser.storage.local.get(configurationId).then(result => {
+chrome.storage.local.get(configurationId, result => {
   const script2 = document.createElement('script');
   const source2 = ''
   + '(function() {'


### PR DESCRIPTION
Currently it seems that I need to rewrite for supporting storage on both FireFox and Chrome

```javascript
browser.storage.local.get(key).then(result => {

});
```

with

```javascript
chrome.storage.local.get(key, result => {

});
```