### PR TITLE
Multiple hand controllers support

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -13,11 +13,14 @@ function ControllerInjection() {
   };
 
   class Controller {
-    constructor(device, hasPosition, hasRotation) {
+    constructor(device, hasPosition, hasRotation, leftRight) {
       this.device = device;
       this.hasPosition = hasPosition;
       this.hasRotation = hasRotation;
       this.active = true;
+
+      // @TODO: define Controller.LEFT/RIGHT
+      this.leftRight = leftRight;
 
       this._keys = {
         enable: 16,            // shift
@@ -61,6 +64,9 @@ function ControllerInjection() {
       };
 
       this._position = new _Math.Vector3(0.2, 0.9, -0.1);
+      if (this.leftRight === 1) {
+        this._position.x = -this._position.x;
+      }
       this._rotation = new _Math.Euler();
       this._quaternion = new _Math.Quaternion();
       this._scale = new _Math.Vector3(1, 1, 1);
@@ -118,13 +124,13 @@ function ControllerInjection() {
         gamepad.buttons[1].pressed = true;
 
         if (session) {
-          session._fireSelectStart(this);
+          session._fireSelectStart(this, this.leftRight);
         }
       } else if (!keyPressed[keys.trigger] && gamepad.buttons[1].pressed) {
         gamepad.buttons[1].pressed = false;
 
         if (session) {
-          session._fireSelectEnd(this);
+          session._fireSelectEnd(this, this.leftRight);
         }
       }
 
@@ -194,7 +200,7 @@ function ControllerInjection() {
       quaternion.toArray(gamepad.pose.orientation);
 
       if (session) {
-        matrix.toArray(session._frame._pose.transform.matrix);
+        matrix.toArray(session._frame._poses[this.leftRight].transform.matrix);
       }
     }
   }

--- a/src/device-manager.js
+++ b/src/device-manager.js
@@ -25,8 +25,13 @@ function XRDeviceManagerInjection() {
       this.device.setSession(session);
     }
 
-    getGamepad() {
-      return this.device.controller.getGamepad();
+    getGamepads() {
+      const array = [];
+      const controllers = this.device.controllers;
+      for (let i = 0, il = controllers.length; i < il; i++) {
+        array[i] = controllers[i].getGamepad();
+      }
+      return array;
     }
 
     serialize() {

--- a/src/devices/base.js
+++ b/src/devices/base.js
@@ -6,7 +6,7 @@
       this.id = 'None';
       this.modes = ['inline'];
       this.headset = null;
-      this.controller = null;
+      this.controllers = [];
       this.session = null;
     }
 

--- a/src/devices/oculus-go.js
+++ b/src/devices/oculus-go.js
@@ -6,7 +6,9 @@
       this.id = 'Oculus Go';
       this.modes.push('immersive-vr');
       this.headset = new Headset(this, false, true);
-      this.controller = new Controller(this, false, true);
+      this.controllers = [
+        new Controller(this, false, true, 0)
+      ];
     }
   }
 

--- a/src/devices/oculus-quest.js
+++ b/src/devices/oculus-quest.js
@@ -6,7 +6,9 @@
       this.id = 'Oculus Quest';
       this.modes.push('immersive-vr');
       this.headset = new Headset(this, true, true);
-      this.controller = new Controller(this, true, true);
+      this.controllers = [
+        new Controller(this, true, true, 0)
+      ];
     }
   }
 


### PR DESCRIPTION
This PR adds multiple hand controllers support.

Note that currently you can't separately control multiple controllers. For example, if you try to move controller left, all controllers will move left. This will be fixed in another PR (maybe for v0.2.0).

So although it has an ability to support multiple controllers now, I don't assign two hand controllers to Oculus Quest yet. After I resolve the above problem I will do.