### PR TITLE
Fix reference error for Chrome.

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -2,7 +2,7 @@ const port = chrome.runtime.connect({name: 'contentScript'});
 
 const dispatchCustomEvent = (type, detail) => {
   window.dispatchEvent(new CustomEvent(type, {
-    detail: cloneInto ? cloneInto(detail, window) : detail
+    detail: typeof cloneInto !== 'undefined' ? cloneInto(detail, window) : detail
   }));
 };
 


### PR DESCRIPTION
Fix for Chrome. Chrome doesn't define cloneInto so need to check the existence with typeof. Otherwise it ends up with Reference error