### PR TITLE
Fix initialValues in panel.js

### DIFF
--- a/panel.js
+++ b/panel.js
@@ -365,7 +365,7 @@ const storeValues = () => {
 // load configuration and then load assets
 
 const configurationId = 'webxr-extension';
-const initialValues = '1:0'.split(':'); // @TODO: Import from Configuration
+const initialValues = [1, 0]; // @TODO: Import from Configuration
 
 chrome.storage.local.get(configurationId, result => {
   const values = (result[configurationId] || '').split(':');


### PR DESCRIPTION
This PR fixes `initialValues` indicating default devices used before device emulator is selected by a user in `panel.js`. It's expected to be an array of integer but currently it's an array of strings. Then device assets aren't loaded unless device emulator is selected. This PR fixes this problem.