### PR TITLE
Clickable device labels to enable transform controls

### DIFF
--- a/panel.html
+++ b/panel.html
@@ -42,9 +42,9 @@
       <br /><br />
       Reload the page to reflect<br />
       the above configuration.<br /><br />
-      <input id="headsetCheckbox" type="checkbox">headset</input><br />
-      <input id="rightHandCheckbox" type="checkbox">right controller</input><br />
-      <input id="leftHandCheckbox" type="checkbox">left controller</input><br />
+      <input id="headsetCheckbox" type="checkbox"><span id="headsetSpan">headset</span></input><br />
+      <input id="rightHandCheckbox" type="checkbox"><span id="rightHandSpan">right controller</span></input><br />
+      <input id="leftHandCheckbox" type="checkbox"><span id="leftHandSpan">left controller</span></input><br />
       <button id="translateButton">translate/rotate</button><br />
       <button id="rightPressButton">right press/release</button><br />
       <button id="leftPressButton">left press/release</button><br />

--- a/panel.js
+++ b/panel.js
@@ -282,40 +282,70 @@ const updateControlsEnability = (domElement, controls) => {
   controls.enabled = checked;
 }
 
-document.getElementById('headsetCheckbox').addEventListener('change', event => {
+const onHeadsetCheckboxChange = () => {
   const controls = transformControls.headset;
 
   if (!controls) {
     return;
   }
 
-  updateControlsEnability(event.target, controls);
+  const checkbox = document.getElementById('headsetCheckbox');
+  updateControlsEnability(checkbox, controls);
   disableTransformControlsIfNeeded(controls, deviceCapabilities.headset);
   render();
-}, false);
+};
 
-document.getElementById('rightHandCheckbox').addEventListener('change', event => {
+document.getElementById('headsetCheckbox')
+  .addEventListener('change', onHeadsetCheckboxChange, false);
+
+document.getElementById('headsetSpan').addEventListener('click', event => {
+  const checkbox = document.getElementById('headsetCheckbox');
+  checkbox.checked = !checkbox.checked;
+  onHeadsetCheckboxChange();
+});
+
+const onRightHandCheckboxChange = () => {
   const controls = transformControls.rightHand;
 
   if (!controls) {
     return;
   }
 
-  updateControlsEnability(event.target, controls);
+  const checkbox = document.getElementById('rightHandCheckbox');
+  updateControlsEnability(checkbox, controls);
   disableTransformControlsIfNeeded(controls, deviceCapabilities.controller);
   render();
+};
+
+document.getElementById('rightHandCheckbox')
+  .addEventListener('change', onRightHandCheckboxChange, false);
+
+document.getElementById('rightHandSpan').addEventListener('click', event => {
+  const checkbox = document.getElementById('rightHandCheckbox');
+  checkbox.checked = !checkbox.checked;
+  onRightHandCheckboxChange();
 }, false);
 
-document.getElementById('leftHandCheckbox').addEventListener('change', event => {
+const onLeftHandCheckboxChange = () => {
   const controls = transformControls.leftHand;
 
   if (!controls) {
     return;
   }
 
-  updateControlsEnability(event.target, controls);
+  const checkbox = document.getElementById('leftHandCheckbox');
+  updateControlsEnability(checkbox, controls);
   disableTransformControlsIfNeeded(controls, deviceCapabilities.controller);
   render();
+};
+
+document.getElementById('leftHandCheckbox')
+  .addEventListener('change', onLeftHandCheckboxChange, false);
+
+document.getElementById('leftHandSpan').addEventListener('click', event => {
+  const checkbox = document.getElementById('leftHandCheckbox');
+  checkbox.checked = !checkbox.checked;
+  onLeftHandCheckboxChange();
 }, false);
 
 document.getElementById('translateButton').addEventListener('click', event => {


### PR DESCRIPTION
Now you can enable/disable transform controls of devices by clicking device labels in panel