### PR TITLE
Add Show Gizmos label to the panel

### DIFF
--- a/panel.html
+++ b/panel.html
@@ -36,6 +36,7 @@
       <!-- @TODO: dynamic configuration update support -->
       Reload the page to reflect<br />
       the above configuration.<br /><br />
+      Show Gizmos<br />
       <span id="headsetCheckboxSpan"><input id="headsetCheckbox" type="checkbox" checked><span id="headsetLabel">headset</span></input></span><br />
       <span id="rightHandCheckboxSpan"><input id="rightHandCheckbox" type="checkbox" checked><span id="rightHandLabel">right controller</span></input></span><br />
       <span id="leftHandCheckboxSpan"><input id="leftHandCheckbox" type="checkbox" checked><span id="leftHandLabel">left controller</span></input></span><br />


### PR DESCRIPTION
From #87

This PR adds "Show Gizmos" label on top of the checkboxes in the panel. Users can understand what the checkboxes are for.

![image](https://user-images.githubusercontent.com/7637832/63895956-8b938b00-c9a5-11e9-987a-878a17698c0e.png)
