### PR TITLE
Reload request message

### DIFF
--- a/panel.html
+++ b/panel.html
@@ -32,10 +32,8 @@
       <br />
       Stereo Effect:
       <select id="stereoSelect"></select>
-      <br /><br />
-      <!-- @TODO: dynamic configuration update support -->
-      Reload the page to reflect<br />
-      the above configuration.<br /><br />
+      <br />
+      <span id="message"></span><br />
       Show Gizmos<br />
       <span id="headsetCheckboxSpan"><input id="headsetCheckbox" type="checkbox" checked><span id="headsetLabel">headset</span></input></span><br />
       <span id="rightHandCheckboxSpan"><input id="rightHandCheckbox" type="checkbox" checked><span id="rightHandLabel">right controller</span></input></span><br />

--- a/panel.js
+++ b/panel.js
@@ -522,6 +522,27 @@ fetch('./devices.json')
     console.error(error);
   });
 
+// Displays message requestig reload the application page
+// when device or stereo effect is changed by user
+
+const displayReloadRequestMessage = () => {
+  const messageSpan = document.getElementById('message');
+  while (messageSpan.childElementCount !== 0) {
+    messageSpan.removeChild(messageSpan.children[0]);
+  }
+  const textSpan = document.createElement('span');
+  textSpan.style.color = '#a00';
+  textSpan.style.background = '#ffd';
+  textSpan.textContent = 'Reload to reflect the change';
+  messageSpan.appendChild(textSpan);
+  // disapears in five seconds.
+  setTimeout(() => {
+    if (textSpan.parentElement !== null) {
+      messageSpan.removeChild(textSpan);
+    }
+  }, 5000);
+};
+
 // load/store configurations
 
 const loadConfiguration = (deviceJson) => {
@@ -541,6 +562,7 @@ const loadConfiguration = (deviceJson) => {
     chrome.storage.local.set(storedValue, () => {
       // window.alert(window); // to check if works
     });
+    displayReloadRequestMessage();
     updateAssetNodes(deviceKey, deviceJson);
   };
 


### PR DESCRIPTION
From #48 and #83

This PR shows the message requesting to reload the application page when device or stereo effect is changed by user in developer tool panel.

A message "Reload the page to reflect the above configuration" already existed under the stereo effect select elements but reviewers didn't notice it so I thought we need something catching users attention more.

![image](https://user-images.githubusercontent.com/7637832/63899067-4e80c600-c9b0-11e9-93ff-7b90f68d95f1.png)
