### PR TITLE
Make Gizmos bigger

### DIFF
--- a/panel.js
+++ b/panel.js
@@ -134,6 +134,7 @@ const createTransformControls = (target, onChange) => {
   controls.setMode(states.translateMode ? 'translate' : 'rotate');
   controls.setSpace('local');
   controls.attach(target);
+  controls.setSize(1.5);
 
   controls.addEventListener('mouseDown', () => {
     orbitControls.enabled = false;


### PR DESCRIPTION
This PR resolves #90 

Three.js TransformsControls gizmo size can be changed with `.setSize()`. Default is 1, and I set 1.5 in this PR.

size 1 (current)

![image](https://user-images.githubusercontent.com/7637832/63972497-bf31ec00-ca5d-11e9-991a-cffea46f207c.png)

![image](https://user-images.githubusercontent.com/7637832/63972516-c658fa00-ca5d-11e9-871d-2a5c3c7b056b.png)

size 1.5 (with this PR)

![image](https://user-images.githubusercontent.com/7637832/63972551-d83a9d00-ca5d-11e9-8d4f-e226cb06f66e.png)

![image](https://user-images.githubusercontent.com/7637832/63972562-dcff5100-ca5d-11e9-99bb-ddf847c3cc71.png)
