### PR TITLE
Replace the icon in devtool panel

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -2,6 +2,6 @@ const port = chrome.runtime.connect(null, {name: 'devtools'});
 
 chrome.devtools.panels.create(
   "WebXR",
-  "icon.png",
+  "icon16.png",
   "panel.html"
 );


### PR DESCRIPTION
This PR replaces the icon in devtool panel tab. I've missed replacing in #102