### PR TITLE
Use 128px icon for devtool panel

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -2,6 +2,6 @@ const port = chrome.runtime.connect(null, {name: 'devtools'});
 
 chrome.devtools.panels.create(
   "WebXR",
-  "icon16.png",
+  "icon128.png",
   "panel.html"
 );


### PR DESCRIPTION
It seems 16px icon is too small for devtool panel.