### PR TITLE
Add touched and value attributes to GamepadButton

### DIFF
--- a/src/EmulatedXRDevice.js
+++ b/src/EmulatedXRDevice.js
@@ -224,6 +224,7 @@ export default class EmulatedXRDevice extends XRDevice {
     if (index >= this.gamepads.length) { return; }
     const gamepad = this.gamepads[index];
     gamepad.buttons[0].pressed = pressed;
+    gamepad.buttons[0].value = pressed ? 1.0 : 0.0;
   }
 
   _initializeControllers(config) {
@@ -319,8 +320,16 @@ const createGamepad = (hand, hasPosition) => {
       orientation: [0, 0, 0, 1]
     },
     buttons: [
-      {pressed: false},
-      {pressed: false}
+      {
+        pressed: false,
+        touched: false,
+        value: 0.0
+      },
+      {
+        pressed: false,
+        touched: false,
+        value: 0.0
+      }
     ],
     hand: hand,
     mapping: 'xr-standard',


### PR DESCRIPTION
This PR adds touched and value attributes to GamepadButton

https://www.w3.org/TR/gamepad/#gamepadbutton-interface

With this change, application relying on them will work for example Controller State example in WebXR samples.