### PR TITLE
Return rAF handle in emulated device

### DIFF
--- a/src/polyfill/EmulatedXRDevice.js
+++ b/src/polyfill/EmulatedXRDevice.js
@@ -91,7 +91,7 @@ export default class EmulatedXRDevice extends XRDevice {
   }
 
   requestAnimationFrame(callback) {
-    this.global.requestAnimationFrame(callback);
+    return this.global.requestAnimationFrame(callback);
   }
 
   cancelAnimationFrame(handle) {


### PR DESCRIPTION
The emulated device's `requestAnimationFrame` wasn't returning its handle. This was preventing proper cleanup with `cancelAnimationFrame`, and potential cases of multiple rAF listeners in flight for the same XRFrame.