### PR TITLE
AR support prototype

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "gl-matrix": "^3.1.0",
-    "webxr-polyfill": "git://github.com/takahirox/webxr-polyfill.git#SqueezeButton"
+    "three": "^0.111.0",
+    "webxr-polyfill": "git://github.com/immersive-web/webxr-polyfill"
   }
 }

--- a/src/devices.json
+++ b/src/devices.json
@@ -90,6 +90,37 @@
         }
       ]
     },
+    "Samsung Galaxy S8+ (AR)": {
+      "id": "Samsung Galaxy S8+ (AR)",
+      "name": "Samsung Galaxy S8+ (AR)",
+      "modes": [
+        "inline",
+        "immersive-ar"
+      ],
+      "headset": {
+        "hasPosition": true,
+        "hasRotation": true
+      },
+      "controllers": [
+        {
+          "hasPosition": true,
+          "hasRotation": true
+        },
+        {
+          "hasPosition": true,
+          "hasRotation": true
+        }
+      ],
+      "resolution": {
+        "width": 1440,
+        "height": 2960
+      },
+      "size": {
+        "width": 0.0734,
+        "height": 0.1595,
+        "depth": 0.0081
+      }
+    },
     "Samsung Gear VR": {
       "id": "Samsung Gear VR",
       "name": "Samsung Gear VR",

--- a/src/polyfill/ARScene.js
+++ b/src/polyfill/ARScene.js
@@ -1,0 +1,212 @@
+import {
+  BoxBufferGeometry,
+  CanvasTexture,
+  Color,
+  DirectionalLight,
+  GridHelper,
+  Mesh,
+  MeshBasicMaterial,
+  MeshStandardMaterial,
+  WebGLRenderer,
+  WebGLRenderTarget,
+  PerspectiveCamera,
+  PlaneBufferGeometry,
+  Scene,
+  SphereBufferGeometry
+} from 'three';
+
+// @TODO: These default values should be imported from somewhere common place
+const DEFAULT_CAMERA_POSITION = [0, 1.6, 0];
+const DEFAULT_TABLET_POSITION = [-0.5, 1.5, -1.0];
+const DEFAULT_POINTER_POSITION = [0.5, 1.5, -1.0];
+
+export default class ARScene {
+  constructor(deviceSize) {
+    this.renderer = null;
+    this.camera = null;
+    this.tablet = null;
+    this.pointer = null;
+    this.screen = null;
+    this._init(deviceSize);
+  }
+
+  _init(deviceSize) {
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+
+    const canvas = document.createElement('canvas');
+    // WebXR app Canvas size can't be power of two size. So using WebGL2.
+    // @TODO: Error message for non WebGL2 support browser?
+    const context = canvas.getContext('webgl2', {antialias: true});
+
+    const renderer = new WebGLRenderer({canvas: canvas, context: context});
+    renderer.setSize(width, height);
+    renderer.setPixelRatio(window.devicePixelRatio);
+
+    // Using 1024 without any special reasons so far
+    const renderTarget = new WebGLRenderTarget(1024, 1024);
+
+    const scene = new Scene();
+    scene.background = new Color(0x444444);
+
+    const camera = new PerspectiveCamera(90, width / height, 0.1, 1000.0);
+    camera.position.fromArray(DEFAULT_CAMERA_POSITION);
+
+    // @TODO: near and far should be from renderState
+    // @TODO: Proper fov
+    const tabletCamera = new PerspectiveCamera(90, deviceSize.width / deviceSize.height, 0.1, 1000.0);
+
+    const light = new DirectionalLight(0xffffff, 4.0);
+    light.position.set(-1, 1, -1);
+    scene.add(light);
+
+    const gridHelper = new GridHelper(20, 20, 0xffffff, 0xdddddd);
+    scene.add(gridHelper);
+
+    const outsideFrameWidth = 0.005;
+    const screen = new Mesh(
+      new PlaneBufferGeometry(deviceSize.width - outsideFrameWidth, deviceSize.height - outsideFrameWidth),
+      new MeshBasicMaterial({color: 0xffffff, map: renderTarget.texture})
+    );
+    screen.position.z = deviceSize.depth * 0.5 + 0.00001;  // 0.00001 is for not hiding the screen by the device
+    screen.add(tabletCamera);
+
+    // Edit shader to mix WebXR app Canvas and ARScene renderTarget.
+    // @TODO: Is there any easier way?
+    screen.material.onBeforeCompile = shader => {
+      // Uniform for WebXR app Canvas.
+      shader.uniforms.map2 = {
+        // Set dummy so far and replace with the right one latter.
+        value: new CanvasTexture(document.createElement('canvas'))
+      };
+      shader.fragmentShader = shader.fragmentShader
+        .replace(
+          '#include <map_pars_fragment>\n',
+          '#include <map_pars_fragment>\n' +
+          'uniform sampler2D map2;\n'
+        ).replace(
+          '#include <map_fragment>\n',
+          // For the simplicity of shader, assuming both map and map2 aren't null
+          'vec4 texelColor = mapTexelToLinear(texture2D(map, vUv));\n' +
+          'vec4 texelColor2 = mapTexelToLinear(texture2D(map2, vUv));\n' +
+          // @TODO: Mix more properly if possible?
+          'diffuseColor *= vec4(texelColor.rgb * (1.0 - texelColor2.a) + texelColor2.rgb * texelColor2.a, texelColor.a);\n'
+        );
+      screen.material.userData.map2 = shader.uniforms.map2;
+      //console.log(shader);
+    };
+
+    const tablet = new Mesh(
+      new BoxBufferGeometry(deviceSize.width, deviceSize.height, deviceSize.depth),
+      new MeshStandardMaterial({color: 0x000000})
+    );
+    tablet.position.fromArray(DEFAULT_TABLET_POSITION);
+    tablet.add(screen);
+    scene.add(tablet);
+
+    const pointer = new Mesh(
+      new SphereBufferGeometry(0.01),
+      new MeshBasicMaterial({color: 0xff8888})
+    );
+    pointer.position.fromArray(DEFAULT_POINTER_POSITION);
+    scene.add(pointer);
+
+    const animate = () => {
+      requestAnimationFrame(animate);
+
+      // First pass. Rendering ARScene to renderTarget.
+
+      screen.visible = false;
+      scene.traverse(object => {
+        if (object.userData.virtual) {
+          object.visible = true;
+        }
+      });
+      renderer.setRenderTarget(renderTarget);
+      renderer.render(scene, tabletCamera);
+
+      // Second pass. Rendering ARScene and screen.
+      // renderTarget and WebXR app Canvas is mixed on screen.
+
+      // @TODO: If possible, update the canvas texture only when the canvas is updated
+      if (screen.material.userData.map2) {
+        screen.material.userData.map2.value.needsUpdate = true;
+      }
+      screen.visible = true;
+      scene.traverse(object => {
+        if (object.userData.virtual) {
+          object.visible = false;
+        }
+      });
+      renderer.setRenderTarget(null);
+      renderer.render(scene, camera);
+    };
+
+    animate();
+
+    window.addEventListener('resize', event => {
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+      renderer.setSize(width, height);
+      camera.aspect = width / height;
+      camera.updateProjectionMatrix();
+    }, false);
+
+    this.renderer = renderer;
+    this.camera = camera;
+    this.screen = screen;
+    this.tablet = tablet;
+    this.pointer = pointer;
+  }
+
+  inject() {
+    const appendCanvas = () => {
+      const element = this.renderer.domElement;
+      element.style.position = 'absolute';
+      element.style.top = '0';
+      element.style.left = '0';
+      element.style.width = '100%';
+      element.style.height = '100%';
+      element.style.zIndex = '9999'; // To override window overall
+      document.body.appendChild(element);
+    };
+
+    if (document.body) {
+      appendCanvas();
+    } else {
+      document.addEventListener('DOMContentLoaded', appendCanvas);
+    }
+  }
+
+  eject() {
+    const element = this.renderer.domElement;
+    element.parentElement.removeChild(element);
+  }
+
+  setCanvas(canvas) {
+    this.screen.material.userData.map2.value = new CanvasTexture(canvas);
+  }
+
+  updateCameraTransform(positionArray, quaternionArray) {
+    this.camera.position.fromArray(positionArray);
+    this.camera.quaternion.fromArray(quaternionArray);
+  }
+
+  updateTabletTransform(positionArray, quaternionArray) {
+    this.tablet.position.fromArray(positionArray);
+    this.tablet.quaternion.fromArray(quaternionArray);
+  }
+
+  updatePointerTransform(positionArray, quaternionArray) {
+    this.pointer.position.fromArray(positionArray);
+    this.pointer.quaternion.fromArray(quaternionArray);
+  }
+
+  touched() {
+    this.pointer.material.color.setHex(0x8888ff);
+  }
+
+  released() {
+    this.pointer.material.color.setHex(0xff8888);
+  }
+}

--- a/src/polyfill/CustomWebXRPolyfill.js
+++ b/src/polyfill/CustomWebXRPolyfill.js
@@ -18,7 +18,7 @@ export default class CustomWebXRPolyfill extends WebXRPolyfill {
     const originalRequestSession = XR.prototype.requestSession;
     XR.prototype.requestSession = function(mode, enabledFeatures) {
       return originalRequestSession.call(this, mode, enabledFeatures).then(session => {
-        if (mode === 'immersive-vr') {
+        if (mode === 'immersive-vr' || mode === 'immersive-ar') {
           activeImmersiveSession = session;
         }
         return session;

--- a/src/polyfill/EmulatedXRDevice.js
+++ b/src/polyfill/EmulatedXRDevice.js
@@ -6,6 +6,7 @@ import {
   quat,
   mat4
 } from 'gl-matrix';
+import ARScene from './ARScene';
 
 const DEFAULT_HEIGHT = 1.6; // @TODO: This value should shared with panel.js?
 
@@ -24,7 +25,7 @@ export default class EmulatedXRDevice extends XRDevice {
     this.quaternion = quat.create();
     this.scale = vec3.fromValues(1, 1, 1);
     this.matrix = mat4.create();
-    this.inlineProjectionMatrix = mat4.create();
+    this.projectionMatrix = mat4.create();
     this.leftProjectionMatrix = mat4.create();
     this.rightProjectionMatrix = mat4.create();
     this.viewMatrix = mat4.create();
@@ -41,7 +42,7 @@ export default class EmulatedXRDevice extends XRDevice {
     // other configurations
     this.stereoEffectEnabled = config.stereoEffect !== undefined ? config.stereoEffect : true;
 
-    this._setupEventListeners();
+    // For case where baseLayer's canvas isn't in document.body
 
     this.div = document.createElement('div');
     this.div.style.position = 'absolute';
@@ -49,6 +50,20 @@ export default class EmulatedXRDevice extends XRDevice {
     this.div.style.height = '100%';
     this.div.style.top = '0';
     this.div.style.left = '0';
+
+    // For AR
+
+    this.resolution = config.resolution !== undefined ? config.resolution : {width: 1024, height: 2048};
+    this.deviceSize = config.size !== undefined ? config.size : {width: 0.05, height: 0.1, depth: 0.005};
+    this.rawCanvasSize = {width: 0, height: 0};
+    this.arScene = null;
+    this.activeARSession = false;
+    this.touched = false;
+    this.canvasParent = null;
+
+    //
+
+    this._setupEventListeners();
   }
 
   onBaseLayerSet(sessionId, layer) {
@@ -59,6 +74,21 @@ export default class EmulatedXRDevice extends XRDevice {
     session.baseLayer = layer;
     if (session.immersive) {
       this._appendBaseLayerCanvasToBodyIfNeeded(sessionId);
+    }
+    if (session.ar) {
+      const canvas = session.baseLayer.context.canvas;
+      this.rawCanvasSize.width = canvas.width;
+      this.rawCanvasSize.height = canvas.height;
+      canvas.width = this.resolution.width;
+      canvas.height = this.resolution.height;
+      this.arScene.setCanvas(canvas);
+      if (canvas.parentElement) {
+        this.canvasParent = canvas.parentElement;
+        // Not sure why but this is necessary for Firefox.
+        // Otherwise, the canvas won't be rendered in AR scene.
+        // @TODO: Figure out the root issue and resolve.
+        this.canvasParent.removeChild(canvas);
+      }
     }
   }
 
@@ -87,6 +117,13 @@ export default class EmulatedXRDevice extends XRDevice {
     if (immersive) {
       this.dispatchEvent('@@webxr-polyfill/vr-present-start', session.id);
     }
+    if (mode === 'immersive-ar') {
+      this.activeARSession = true;
+      if (!this.arScene) {
+        this.arScene = new ARScene(this.deviceSize);
+      }
+      this.arScene.inject();
+    }
     return Promise.resolve(session.id);
   }
 
@@ -107,14 +144,18 @@ export default class EmulatedXRDevice extends XRDevice {
     const width = canvas.width;
     const height = canvas.height;
 
-    if (session.immersive) {
+    if (session.vr) {
       // @TODO: proper FOV
       const aspect = width * (this.stereoEffectEnabled ? 0.5 : 1.0) / height;
       mat4.perspective(this.leftProjectionMatrix, Math.PI / 2, aspect, near, far);
       mat4.perspective(this.rightProjectionMatrix, Math.PI / 2, aspect, near, far);
+    } else if (session.ar) {
+      // @TODO: proper FOV
+      const aspect = this.resolution.width / this.resolution.height;
+      mat4.perspective(this.projectionMatrix, Math.PI / 2, aspect, near, far);
     } else {
       const aspect = width / height;
-      mat4.perspective(this.inlineProjectionMatrix, session.inlineVerticalFieldOfView, aspect, near, far);
+      mat4.perspective(this.projectionMatrix, session.inlineVerticalFieldOfView, aspect, near, far);
     }
     mat4.fromRotationTranslationScale(this.matrix, this.quaternion, this.position, this.scale);
     mat4.invert(this.viewMatrix, this.matrix);
@@ -128,6 +169,22 @@ export default class EmulatedXRDevice extends XRDevice {
     // @TODO: If there are multiple immersive sessions, input events are fired only for the first session.
     //        Fix this issue (if multiple immersive sessions can be created).
     if (session.immersive) {
+      if (this.activeARSession) {
+        if (this._isTouched()) {
+          if (!this.touched) {
+            this._updateInputButtonPressed(true, 0, 0);
+            this.touched = true;
+            this.arScene.touched();
+          }
+        } else {
+          if (this.touched) {
+            this._updateInputButtonPressed(false, 0, 0);
+            this.touched = false;
+            this.arScene.released();
+          }
+        }
+      }
+
       for (let i = 0; i < this.gamepads.length; ++i) {
         const gamepad = this.gamepads[i];
         const inputSourceImpl = this.gamepadInputSources[i];
@@ -182,6 +239,17 @@ export default class EmulatedXRDevice extends XRDevice {
     const session = this.sessions.get(sessionId);
     if (session.immersive) {
       this._removeBaseLayerCanvasFromBodyIfNeeded(sessionId);
+      if (session.ar) {
+        this.activeARSession = false;
+        this.arScene.eject();
+        const canvas = session.baseLayer.context.canvas;
+        if (this.canvasParent) {
+          this.canvasParent.appendChild(canvas);
+          this.canvasParent = null;
+        }
+        canvas.width = this.rawCanvasSize.width;
+        canvas.height = this.rawCanvasSize.height;
+      }
       this.dispatchEvent('@@webxr-polyfill/vr-present-end', sessionId);
     }
     session.ended = true;
@@ -200,23 +268,39 @@ export default class EmulatedXRDevice extends XRDevice {
     const canvas = session.baseLayer.context.canvas;
     const width = canvas.width;
     const height = canvas.height;
-    if (eye === 'none') {
+    if (session.ar) {
+      // Assuming two viwes left/right. And render only left.
+      // @TODO: Send feedback to webxr-polyfill.js about one none view option.
+      // @TODO: Support AR + stereotypic rendering device
+      if (eye === 'right') {
+        target.width = 0;
+        target.height = 0;
+      } else {
+        target.width = this.resolution.width;
+        target.height = this.resolution.height;
+      }
       target.x = 0;
-      target.width = width;
-    } else if (this.stereoEffectEnabled) {
-      target.x = eye === 'left' ? 0 : width / 2;
-      target.width = width / 2;
+      target.y = 0;
+      return true;
     } else {
-      target.x = 0;
-      target.width = eye === 'left' ? width : 0;
+      if (eye === 'none') {
+        target.x = 0;
+        target.width = width;
+      } else if (this.stereoEffectEnabled) {
+        target.x = eye === 'left' ? 0 : width / 2;
+        target.width = width / 2;
+      } else {
+        target.x = 0;
+        target.width = eye === 'left' ? width : 0;
+      }
+      target.y = 0;
+      target.height = height;
+      return true;
     }
-    target.y = 0;
-    target.height = height;
-    return true;
   }
 
   getProjectionMatrix(eye) {
-    return eye === 'none' ? this.inlineProjectionMatrix :
+    return this.activeARSession || eye === 'none' ? this.projectionMatrix :
            eye === 'left' ? this.leftProjectionMatrix : this.rightProjectionMatrix;
   }
 
@@ -225,7 +309,7 @@ export default class EmulatedXRDevice extends XRDevice {
   }
 
   getBaseViewMatrix(eye) {
-    if (eye === 'none' || !this.stereoEffectEnabled) { return this.viewMatrix; }
+    if (eye === 'none' || this.activeARSession || !this.stereoEffectEnabled) { return this.viewMatrix; }
     return eye === 'left' ? this.leftViewMatrix : this.rightViewMatrix;
   }
 
@@ -240,7 +324,26 @@ export default class EmulatedXRDevice extends XRDevice {
   getInputPose(inputSource, coordinateSystem, poseType) {
     for (const inputSourceImpl of this.gamepadInputSources) {
       if (inputSourceImpl.inputSource === inputSource) {
-        return inputSourceImpl.getXRPose(coordinateSystem, poseType);
+        const pose = inputSourceImpl.getXRPose(coordinateSystem, poseType);
+
+        // In AR mode, calculate the input pose for right controller
+        // from the relation of right controller(pointer) and left controller(tablet)
+        // @TODO: Transient input
+        if (this.activeARSession && inputSourceImpl === this.gamepadInputSources[0]) {
+          // @TODO: Optimize if possible
+          const viewMatrixInverse = mat4.invert(mat4.create(), this.viewMatrix);
+          coordinateSystem._transformBasePoseMatrix(viewMatrixInverse, viewMatrixInverse);
+          const viewMatrix = mat4.invert(mat4.create(), viewMatrixInverse);
+          mat4.multiply(pose.transform.matrix, viewMatrix, pose.transform.matrix);
+          const matrix = mat4.identity(mat4.create());
+          matrix[8] = -pose.transform.matrix[12] / (this.deviceSize.width * 0.5) * this.resolution.width / this.resolution.height;
+          matrix[9] = -(pose.transform.matrix[13]) / (this.deviceSize.height * 0.5);
+          matrix[10] = 1.0;
+          mat4.multiply(pose.transform.matrix, viewMatrixInverse, matrix);
+          mat4.invert(pose.transform.inverse.matrix, pose.transform.matrix);
+        }
+
+        return pose;
       }
     }
     return null;
@@ -330,8 +433,24 @@ export default class EmulatedXRDevice extends XRDevice {
     for (let i = 0; i < controllerNum; i++) {
       const hasPosition = config.controllers[i].hasPosition;
       this.gamepads.push(createGamepad(i === 0 ? 'right' : 'left', hasPosition));
+      // @TODO: targetRayMode should be screen for right controller(pointer) in AR
       this.gamepadInputSources.push(new GamepadXRInputSource(this, null, 0, 1));
     }
+  }
+
+  // For AR. Check if right controller(pointer) is touched with left controller(tablet)
+
+  _isTouched() {
+    // @TODO: Optimize if possible
+    const pose = this.gamepads[0].pose;
+    const matrix = mat4.fromRotationTranslation(mat4.create(), pose.orientation, pose.position);
+    mat4.multiply(matrix, this.viewMatrix, matrix);
+    const dx = matrix[12] / (this.deviceSize.width * 0.5);
+    const dy = matrix[13] / (this.deviceSize.height * 0.5);
+    const dz = matrix[14];
+    return dx <= 1.0 && dx >= -1.0 &&
+           dy <= 1.0 && dy >= -1.0 &&
+           dz <= 0.1 && dz >= 0.0;
   }
 
   // Set up event listeners. Events are sent from panel via background.
@@ -362,7 +481,12 @@ export default class EmulatedXRDevice extends XRDevice {
     window.addEventListener('webxr-pose', event => {
       const positionArray = event.detail.position;
       const quaternionArray = event.detail.quaternion;
-      this._updatePose(positionArray, quaternionArray);
+      if (this.activeARSession) {
+        // In AR-mode, emulated headset corresponds to camera in AR scene
+        this.arScene.updateCameraTransform(positionArray, quaternionArray);
+      } else {
+        this._updatePose(positionArray, quaternionArray);
+      }
     }, false);
 
     window.addEventListener('webxr-input-pose', event => {
@@ -370,16 +494,36 @@ export default class EmulatedXRDevice extends XRDevice {
       const quaternionArray = event.detail.quaternion;
       const objectName = event.detail.objectName;
 
-      switch (objectName) {
-        case 'rightController':
-        case 'leftController':
-          this._updateInputPose(positionArray, quaternionArray,
-            objectName === 'rightController' ? 0 : 1); // @TODO: remove magic number
-          break;
+      if (this.activeARSession) {
+        // In AR-mode, right controller corresponds to pointer and left controller corresponds to tablet
+        switch (objectName) {
+          case 'rightController':
+            this._updateInputPose(positionArray, quaternionArray, 0);
+            this.arScene.updatePointerTransform(positionArray, quaternionArray);
+            break;
+          case 'leftController':
+            this._updatePose(positionArray, quaternionArray);
+            this.arScene.updateTabletTransform(positionArray, quaternionArray);
+            break;
+        }
+      } else {
+        switch (objectName) {
+          case 'rightController':
+          case 'leftController':
+            this._updateInputPose(positionArray, quaternionArray,
+              objectName === 'rightController' ? 0 : 1); // @TODO: remove magic number
+            break;
+        }
       }
     });
 
     window.addEventListener('webxr-input-button', event => {
+      // Ignore button trigger in AR mode
+      // @TODO: Disable button in devtool panel in AR mode
+      if (this.activeARSession) {
+        return;
+      }
+
       const pressed = event.detail.pressed;
       const objectName = event.detail.objectName;
       const buttonIndex = event.detail.buttonIndex;
@@ -405,6 +549,8 @@ class Session {
   constructor(mode, enabledFeatures) {
     this.mode = mode;
     this.immersive = mode == 'immersive-vr' || mode == 'immersive-ar';
+    this.vr = mode === 'immersive-vr';
+    this.ar = mode === 'immersive-ar';
     this.id = ++SESSION_ID;
     this.baseLayer = null;
     this.inlineVerticalFieldOfView = Math.PI * 0.5;


### PR DESCRIPTION
Related #105.

This PR adds AR support prototype.

![ezgif com-optimize (1)](https://user-images.githubusercontent.com/7637832/70841030-d659d700-1dcb-11ea-8e43-e792633af1a3.gif)

You can test WebXR application in virtual space. Currently Right controller is mapped to pointer(finger) and Left controller is mapped to tablet (or phone). input select start event is fired If pointer is close enough to tablet. int select end event is fired if pointer move further enough from tablet.

There still be a lot of things to consider, optimize, and clean up. Also I'm not sure yet if this virtual space approach is the best. But I think it's a good start and I want feedback. So I'd like to go with this as experimental feature so far. I'm going to revert if this won't be good.

How to try.
1. [Manually install the extension from the source code in this repository](https://github.com/MozillaReality/WebXR-emulator-extension#for-development)
2. Open WebXR tab in devtool panel and select "Samsung Galaxy S8+ (AR)" device
3. Go to [Three.js WebXR AP-Paint example](https://threejs.org/examples/#webxr_ar_paint)
4. Click "Start AR" button in the example