### PR TITLE
Remove gizmo checkboxes, selectable items by clicking instead

### DIFF
--- a/src/app/panel.html
+++ b/src/app/panel.html
@@ -152,7 +152,6 @@
       </div>
       <div id="renderComponent" class="component main-component"></div>
       <div class="title-bar border-top">
-        <button id="transformModeButton">Rotate</button>
         <button id="resetPoseButton">Reset pose</button>
         <button id="exitButton">Exit immersive</button>
       </div>
@@ -161,7 +160,6 @@
       <div id="headsetComponent" class="component device-property-component">
         <div class="title-bar"><span class="icon">&#9660;</span>Headset</div>
         <div class="component device-property-content">
-          <div><label><input id="headsetCheckbox" type="checkbox" checked> Gizmo</label></div>
           <div><span class="key">position:</span> <span class="value" id="headsetPosition"></span></div>
           <div><span class="key">rotation:</span> <span class="value" id="headsetRotation"></span></div>
         </div>
@@ -169,7 +167,6 @@
       <div id="rightControllerComponent" class="component device-property-component">
         <div class="title-bar"><span class="icon">&#9660;</span>Right controller</div>
         <div class="component device-property-content">
-          <div><label><input id="rightControllerCheckbox" type="checkbox" checked> Gizmo</label></div>
           <div><span class="key">position:</span> <span class="value" id="rightControllerPosition"></span></div>
           <div><span class="key">rotation:</span> <span class="value" id="rightControllerRotation"></span></div>
           <div><button class="trigger-button" id="rightSelectButton">select button</button>
@@ -179,7 +176,6 @@
       <div id="leftControllerComponent" class="component device-property-component">
         <div class="title-bar"><span class="icon">&#9660;</span>Left controller</div>
         <div class="component device-property-content">
-          <div><label><input id="leftControllerCheckbox" type="checkbox" checked> Gizmo</label></div>
           <div><span class="key">position:</span> <span class="value" id="leftControllerPosition"></span></div>
           <div><span class="key">rotation:</span> <span class="value" id="leftControllerRotation"></span></div>
           <div><button class="trigger-button" id="leftSelectButton">select button</button>


### PR DESCRIPTION
Resolves #161.

This PR removes gizmo checkboxes, make the items selectable by clicking instead. [Video](https://twitter.com/superhoge/status/1209264497606549506)

@feiss I display gizmo either translate or rotate so far. Please open an issue if displayting the both at the same time looks better (from https://github.com/MozillaReality/WebXR-emulator-extension/issues/161#issuecomment-567891712)