### PR TITLE
Corrected eye offset

### DIFF
--- a/src/polyfill/EmulatedXRDevice.js
+++ b/src/polyfill/EmulatedXRDevice.js
@@ -688,11 +688,7 @@ const createGamepad = (hand, hasPosition) => {
 
 // From Three.js Object3D.translateOnAxis
 const tmpVec3 = vec3.create();
-const tmpQuat = quat.create();
 const translateOnX = (matrix, distance) => {
-  vec3.set(tmpVec3, 1, 0, 0);
-  mat4.getRotation(tmpQuat, matrix);
-  vec3.transformQuat(tmpVec3, tmpVec3, tmpQuat);
-  vec3.set(tmpVec3, tmpVec3[0] * distance, tmpVec3[1] * distance, tmpVec3[2] * distance);
+  vec3.set(tmpVec3, distance, 0, 0);
   return mat4.translate(matrix, matrix, tmpVec3);
 };


### PR DESCRIPTION
The eyes (views) matrices seem to have incorrect translation components in
relation to the pose matrix.

In the initial (reset) pose, which is represented by an identity matrix, the
left eye matrix has a translation of [-0.02, 0.00, 0.00], which corresponds to
the eye located to the left of the face's (headset's) center.

If we move the device 1 unit forward, the pose will be represented by a matrix
with a translation of [0.00, 0.00, -1.00], and the left eye translation
component will be [-0.02, 0.00, -1.00]. So far so good.

Now consider the device moved 1 unit forward like before, but then additionally
rotated around upward Y axis (yaw) left by (positive) 90 degrees (which the
extension panel will display as "rotation: 0.00 1.56 0.00").
As expected, the pose translation doesn't change (we just rotated it in place).
The left eye's translation however becomes [0.02, 0.00, -1.00], which places it
"behind" the rotated headset.
Similarly, the right eye's translation becomes [-0.02, 0.00, -1.00], which is
"in front" of the rotated headset.

The issue seems to be the translateOnX function inside EmulatedXRDevice.js.
The mat4.translate generally translates the matrix inside its local coordinates
space, but in our case the translation vector (which should represent an "eye
offset" inside the "head space") is first rotated by the matrix's rotation
component, so its effective rotation is kind of applied twice.

If the "eye offset" is instead passed straight (without the rotation) to the
mat4.translate, that yields correct results of [0.00, 0.00, -0.98] for the left
eye, and [0.00, 0.00, -1.02] for the right one.