### PR TITLE
Support XRInpurSource.profiles

### DIFF
--- a/src/devices.json
+++ b/src/devices.json
@@ -36,11 +36,19 @@
       },
       "controllers": [
         {
+          "id": "OpenVR Gamepad",
+          "buttonNum": 3,
+          "primaryButtonIndex": 0,
+          "primarySqueezeButtonIndex": 1,
           "hasPosition": true,
           "hasRotation": true,
           "hasSqueezeButton": true
         },
         {
+          "id": "OpenVR Gamepad",
+          "buttonNum": 3,
+          "primaryButtonIndex": 0,
+          "primarySqueezeButtonIndex": 1,
           "hasPosition": true,
           "hasRotation": true,
           "hasSqueezeButton": true
@@ -60,6 +68,9 @@
       },
       "controllers": [
         {
+          "id": "Oculus Go Controller",
+          "buttonNum": 3,
+          "primaryButtonIndex": 0,
           "hasPosition": false,
           "hasRotation": true,
           "hasSqueezeButton": false
@@ -79,11 +90,19 @@
       },
       "controllers": [
         {
+          "id": "Oculus Touch (Right)",
+          "buttonNum": 6,
+          "primaryButtonIndex": 0,
+          "primarySqueezeButtonIndex": 1,
           "hasPosition": true,
           "hasRotation": true,
           "hasSqueezeButton": true
         },
         {
+          "id": "Oculus Touch (Left)",
+          "buttonNum": 6,
+          "primaryButtonIndex": 0,
+          "primarySqueezeButtonIndex": 1,
           "hasPosition": true,
           "hasRotation": true,
           "hasSqueezeButton": true
@@ -103,10 +122,14 @@
       },
       "controllers": [
         {
+          "buttonNum": 1,
+          "primaryButtonIndex": 0,
           "hasPosition": true,
           "hasRotation": true
         },
         {
+          "buttonNum": 1,
+          "primaryButtonIndex": 0,
           "hasPosition": true,
           "hasRotation": true
         }
@@ -134,6 +157,9 @@
       },
       "controllers": [
         {
+          "id": "Gear VR Controller",
+          "buttonNum": 3,
+          "primaryButtonIndex": 0,
           "hasPosition": false,
           "hasRotation": true
         }

--- a/src/polyfill/EmulatedXRDevice.js
+++ b/src/polyfill/EmulatedXRDevice.js
@@ -531,10 +531,15 @@ export default class EmulatedXRDevice extends XRDevice {
     this.gamepads.length = 0;
     this.gamepadInputSources.length = 0;
     for (let i = 0; i < controllerNum; i++) {
-      const hasPosition = config.controllers[i].hasPosition;
-      this.gamepads.push(createGamepad(i === 0 ? 'right' : 'left', hasPosition));
+      const controller = config.controllers[i];
+      const id = controller.id || '';
+      const hasPosition = controller.hasPosition || false;
+      const buttonNum = controller.buttonNum || 0;
+      const primaryButtonIndex = controller.primaryButtonIndex !== undefined ? controller.primaryButtonIndex : 0;
+      const primarySqueezeButtonIndex = controller.primarySqueezeButtonIndex !== undefined ? controller.primarySqueezeButtonIndex : -1;
+      this.gamepads.push(createGamepad(id, i === 0 ? 'right' : 'left', buttonNum, hasPosition));
       // @TODO: targetRayMode should be screen for right controller(pointer) in AR
-      this.gamepadInputSources.push(new GamepadXRInputSource(this, null, 0, 1));
+      this.gamepadInputSources.push(new GamepadXRInputSource(this, {}, primaryButtonIndex, primarySqueezeButtonIndex));
     }
   }
 
@@ -658,27 +663,23 @@ class Session {
   }
 }
 
-const createGamepad = (hand, hasPosition) => {
+const createGamepad = (id, hand, buttonNum, hasPosition) => {
+  const buttons = [];
+  for (let i = 0; i < buttonNum; i++) {
+    buttons.push({
+      pressed: false,
+      touched: false,
+      value: 0.0
+    });
+  }
   return {
+    id: id || '',
     pose: {
       hasPosition: hasPosition,
       position: [0, 0, 0],
       orientation: [0, 0, 0, 1]
     },
-    buttons: [
-      // select
-      {
-        pressed: false,
-        touched: false,
-        value: 0.0
-      },
-      // squeeze
-      {
-        pressed: false,
-        touched: false,
-        value: 0.0
-      }
-    ],
+    buttons: buttons,
     hand: hand,
     mapping: 'xr-standard',
     axes: [0, 0]


### PR DESCRIPTION
This PR adds `XRInputSource.profiles` support and fixes #194. The emulator can work with Three.js `XRControllerFactory` now.

Oculus Quest controller
![image](https://user-images.githubusercontent.com/7637832/74069480-2eb7ea00-49b3-11ea-8c3f-6aa54db7a4f1.png)

Oculus Go controller
![image](https://user-images.githubusercontent.com/7637832/74069496-38d9e880-49b3-11ea-9dc3-285e2aa1a59c.png)

The pictures are of [Three.js VR ballshooter example](https://threejs.org/examples/#webxr_vr_ballshooter). The controller(grip) direction looks weird against the ray. There is a chance that is a [webxr-polyfill.js](https://github.com/immersive-web/webxr-polyfill) problem, I'm going to report.