### PR TITLE
Disable screen touch input while mouse right button is not being pressed on the tablet screen in AR virtual room

### DIFF
--- a/src/polyfill/ARScene.js
+++ b/src/polyfill/ARScene.js
@@ -40,8 +40,8 @@ export default class ARScene {
     this.isTouched = false;
     this.onCameraPoseUpdate = null;
     this.onTabletPoseUpdate = null;
-    this.onTouch = null; // callback fired when mouse clicks the screen
-    this.onRelease = null; // callback fired when screen touch is released
+    this.onTouch = null; // callback fired when mouse clicks the tablet screen
+    this.onRelease = null; // callback fired when the tablet screen touch is released
 
     this._init(deviceSize);
   }
@@ -124,6 +124,7 @@ export default class ARScene {
       new SphereBufferGeometry(0.01),
       new MeshBasicMaterial({color: 0xff8888, transparent: true, opacity: 0.6})
     );
+    pointer.visible = false;
     pointer.position.fromArray(DEFAULT_POINTER_POSITION);
     scene.add(pointer);
 
@@ -386,9 +387,11 @@ export default class ARScene {
 
   touched() {
     this.pointer.material.color.setHex(0x8888ff);
+    this.pointer.visible = true;
   }
 
   released() {
     this.pointer.material.color.setHex(0xff8888);
+    this.pointer.visible = false;
   }
 }


### PR DESCRIPTION
The current screen touch input is designed that the input event is fired if the pointer (right controller) is close enough to the tablet (left controller) for the case where VR browser supports WebExtensions API in the future and enables testing AR on VR.

But it's a bit annoying to desktop users because input event can be fired even if user didn't intend to fire, for example user just wants to rotate the tablet but it hits to the pointer.

In the current UI dekstop user can control the pointer right on the tablet screen by pressing and dragging mouse right button on the tablet screen in AR virtual room as if touching the tablet screen. So disabling screen touch input while mouse right button is not being pressed on the tablet screen so far. It improves the user experience.