### PR TITLE
Remove stereo effect checkbox and input buttons for AR device

### DIFF
--- a/src/app/panel.html
+++ b/src/app/panel.html
@@ -147,7 +147,7 @@
     <div class="component main-component">
       <div class="title-bar">
         <select id="deviceSelect"></select>
-        <label><input id="stereoCheckbox" type="checkbox" checked>Stereo effect</label>
+        <label id="stereoEffectLabel"><input id="stereoCheckbox" type="checkbox" checked>Stereo effect</label>
         <span id="devicePropertiesExpandIcon" class="item-left icon">&#9660;</span>
       </div>
       <div id="renderComponent" class="component main-component"></div>
@@ -169,7 +169,7 @@
         <div class="component device-property-content">
           <div><span class="key">position:</span> <span class="value" id="rightControllerPosition"></span></div>
           <div><span class="key">rotation:</span> <span class="value" id="rightControllerRotation"></span></div>
-          <div><button class="trigger-button" id="rightSelectButton">select button</button>
+          <div><button class="trigger-button" id="rightSelectButton">select button</button></div>
           <div><button class="trigger-button" id="rightSqueezeButton">squeeze button</button></div>
         </div>
       </div>
@@ -178,7 +178,7 @@
         <div class="component device-property-content">
           <div><span class="key">position:</span> <span class="value" id="leftControllerPosition"></span></div>
           <div><span class="key">rotation:</span> <span class="value" id="leftControllerRotation"></span></div>
-          <div><button class="trigger-button" id="leftSelectButton">select button</button>
+          <div><button class="trigger-button" id="leftSelectButton">select button</button></div>
           <div><button class="trigger-button" id="leftSqueezeButton">squeeze button</button></div>
         </div>
       </div>

--- a/src/app/panel.js
+++ b/src/app/panel.js
@@ -445,11 +445,14 @@ const updateAssetNodes = (deviceDefinition) => {
   deviceCapabilities[DEVICE.CONTROLLER].hasPosition = false;
   deviceCapabilities[DEVICE.CONTROLLER].hasRotation = false;
   deviceCapabilities[DEVICE.CONTROLLER].hasSqueezeButton = false;
+  document.getElementById('stereoEffectLabel').style.display = 'none';
   document.getElementById('headsetComponent').style.display = 'none';
   document.getElementById('rightControllerComponent').style.display = 'none';
   document.getElementById('leftControllerComponent').style.display = 'none';
   document.getElementById('resetPoseButton').style.display = 'none';
   document.getElementById('exitButton').style.display = 'none';
+  document.getElementById('rightSelectButton').style.display = 'none';
+  document.getElementById('leftSelectButton').style.display = 'none';
   document.getElementById('rightSqueezeButton').style.display = 'none';
   document.getElementById('leftSqueezeButton').style.display = 'none';
   updateTriggerButtonColor(DEVICE.RIGHT_CONTROLLER, BUTTON.SELECT, false);
@@ -459,6 +462,7 @@ const updateAssetNodes = (deviceDefinition) => {
 
   // secondly load new assets and enable necessary panel controls
 
+  const hasImmersiveVR = deviceDefinition.modes && !! deviceDefinition.modes.includes('immersive-vr');
   const hasHeadset = !! deviceDefinition.headset;
   const hasRightController = deviceDefinition.controllers && deviceDefinition.controllers.length > 0;
   const hasLeftController = deviceDefinition.controllers && deviceDefinition.controllers.length > 1;
@@ -472,6 +476,10 @@ const updateAssetNodes = (deviceDefinition) => {
   const hasPosition = deviceCapabilities[DEVICE.HEADSET].hasPosition ||
     deviceCapabilities[DEVICE.CONTROLLER].hasPosition;
 
+  if (hasImmersiveVR) {
+    document.getElementById('stereoEffectLabel').style.display = '';
+  }
+
   if (hasHeadset) {
     loadHeadsetAsset();
     document.getElementById('headsetComponent').style.display = 'flex';
@@ -484,6 +492,9 @@ const updateAssetNodes = (deviceDefinition) => {
 
   if (hasRightController) {
     document.getElementById('rightControllerComponent').style.display = 'flex';
+    if (hasImmersiveVR) {
+      document.getElementById('rightSelectButton').style.display = '';
+    }
     if (deviceCapabilities[DEVICE.CONTROLLER].hasSqueezeButton) {
       document.getElementById('rightSqueezeButton').style.display = '';
     }
@@ -491,6 +502,9 @@ const updateAssetNodes = (deviceDefinition) => {
 
   if (hasLeftController) {
     document.getElementById('leftControllerComponent').style.display = 'flex';
+    if (hasImmersiveVR) {
+      document.getElementById('leftSelectButton').style.display = '';
+    }
     if (deviceCapabilities[DEVICE.CONTROLLER].hasSqueezeButton) {
       document.getElementById('leftSqueezeButton').style.display = '';
     }


### PR DESCRIPTION
Fixes #183

This PR removes stereo effect checkbox for non stereotypic rendering device and removes input buttons for AR device which doesn't have input controller.