### PR TITLE
Add icons field under the root manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,11 @@
   "minimum_chrome_version": "10.0",
   "devtools_page": "src/extension/devtools.html",
   "description": "WebXR API Emulator",
+  "icons": {
+    "16": "icons/icon16.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  },
   "background": {
     "scripts": ["src/extension/background.js"]
   },


### PR DESCRIPTION
Because of missing the field, icon doesn't seem to be displayed on Chrome Web Store.