### PR TITLE
DOM Overlay API support

### DIFF
--- a/src/polyfill/ARScene.js
+++ b/src/polyfill/ARScene.js
@@ -319,16 +319,9 @@ export default class ARScene {
     this.room = null;
   }
 
-  inject() {
+  inject(div) {
     const appendCanvas = () => {
-      const element = this.renderer.domElement;
-      element.style.position = 'absolute';
-      element.style.top = '0';
-      element.style.left = '0';
-      element.style.width = '100%';
-      element.style.height = '100%';
-      element.style.zIndex = '10000'; // To override window overall
-      document.body.appendChild(element);
+      div.appendChild(this.renderer.domElement);
     };
 
     if (document.body) {

--- a/src/polyfill/CustomWebXRPolyfill.js
+++ b/src/polyfill/CustomWebXRPolyfill.js
@@ -25,6 +25,16 @@ export default class CustomWebXRPolyfill extends WebXRPolyfill {
       return originalRequestSession.call(this, mode, enabledFeatures).then(session => {
         if (mode === 'immersive-vr' || mode === 'immersive-ar') {
           activeImmersiveSession = session;
+
+          // DOM-Overlay API
+          const optionalFeatures = enabledFeatures.optionalFeatures;
+          const domOverlay = enabledFeatures.domOverlay;
+          if (optionalFeatures && optionalFeatures.includes('dom-overlay') &&
+            domOverlay && domOverlay.root) {
+            const device = session[XRSESSION_PRIVATE].device;
+            device.setDomOverlayRoot(domOverlay.root);
+            session.domOverlayState = { type: 'screen' };
+          }
         }
         return session;
       });


### PR DESCRIPTION
This PR adds DOM overlay API support with the approach I mentioned in https://github.com/MozillaReality/WebXR-emulator-extension/issues/222#issuecomment-626083760, just putting the dom overlay elements on the canvas as [screen type](https://immersive-web.github.io/dom-overlays/#initialization).

This is not perfectly emulating the real behavior. For example, ideally the DOM elements should be rendered in 3D scene and the events (e.g. click event) should be fired with xr input. And in AR mode the elements should be rendered in emulated device.

But with the current web API, it's very difficult to do them especially with precisely keeping the quality, dom hierarchies, events, and JavaScript code. (Main issue is there is no proper way to render dom elements in Canvas/Texture.)

So the approach used in this PR would be a reasonable solution. It doesn't emulate perfectly, but would be still useful for users. For example they can test a case where dom event listener has an effect to VR 3D scene, like adding a new object by clicking a button.

And on desktop, it would be easier to click dom elements rather than touching them with xr controllers.

![image](https://user-images.githubusercontent.com/7637832/82389331-bd93c400-99f0-11ea-879b-f0b7cd243e76.png)

![image](https://user-images.githubusercontent.com/7637832/82389431-03508c80-99f1-11ea-8126-ce261ac61451.png)
