### PR TITLE
Enhance popup readability

### DIFF
--- a/src/extension/popup.html
+++ b/src/extension/popup.html
@@ -1,8 +1,15 @@
 <html>
-<head></head>
-<body>
-<p style="font-weight: bold;">WebXR device emulator browser extension</p>
-
-<p>Open "WebXR" tab in the developer tool to control the emulated device.</p>
-</body>
+    <head>
+        <style>
+            body {
+                width: 250px;
+            }
+        </style>
+    </head>
+    <body>
+        <center>
+            <p style="font-weight: bold;">WebXR device emulator browser extension</p>
+            <p>Open "WebXR" tab in the developer tool to control the emulated device.</p>
+        </center>
+    </body>
 </html>


### PR DESCRIPTION
A tiny fix: makes the popup a little more readable. 

The popup before:

![Screen Shot 2021-06-01 at 1 21 11 PM](https://user-images.githubusercontent.com/69025547/120385901-d4941400-c2dc-11eb-9961-9a8bfa863562.png)

Now:

![Screen Shot 2021-06-01 at 1 19 42 PM](https://user-images.githubusercontent.com/69025547/120385918-d78f0480-c2dc-11eb-9aaa-7814e973e52a.png)

It uses CSS to set the width property for the popup. \
This works on Chrome, but I haven't tested for Firefox.
