### PR TITLE
Auto generate buttons and joystick from WebXR Input Profiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   "dependencies": {
     "gl-matrix": "^3.1.0",
     "three": "^0.111.0",
-    "webxr-polyfill": "^2.0.3"
+    "webxr-polyfill": "git+https://github.com/fe1ixz/webxr-polyfill.git"
   }
 }

--- a/src/app/panel.html
+++ b/src/app/panel.html
@@ -98,6 +98,10 @@
         background-color: #e8e8e8;
       }
 
+      button:disabled {
+        background-color: #D3D3D3;
+      }
+
       button.pressed {
         background-color: #0074e8;
         border-color: #fff;
@@ -141,6 +145,15 @@
         color: #929294;
         margin-left: -15px;
       }
+
+      .horizontal-half-container {
+        display: inline-block; 
+        *display: inline; 
+        zoom: 1; 
+        vertical-align: top; 
+        font-size: 12px;
+        width: 50%;
+      }
     </style>
   </head>
   <body>
@@ -164,24 +177,6 @@
           <div><span class="key">rotation:</span> <span class="value" id="headsetRotation"></span></div>
         </div>
       </div>
-      <div id="rightControllerComponent" class="component device-property-component">
-        <div class="title-bar"><span class="icon">&#9660;</span>Right controller</div>
-        <div class="component device-property-content">
-          <div><span class="key">position:</span> <span class="value" id="rightControllerPosition"></span></div>
-          <div><span class="key">rotation:</span> <span class="value" id="rightControllerRotation"></span></div>
-          <div><button class="trigger-button" id="rightSelectButton">select button</button></div>
-          <div><button class="trigger-button" id="rightSqueezeButton">squeeze button</button></div>
-        </div>
-      </div>
-      <div id="leftControllerComponent" class="component device-property-component">
-        <div class="title-bar"><span class="icon">&#9660;</span>Left controller</div>
-        <div class="component device-property-content">
-          <div><span class="key">position:</span> <span class="value" id="leftControllerPosition"></span></div>
-          <div><span class="key">rotation:</span> <span class="value" id="leftControllerRotation"></span></div>
-          <div><button class="trigger-button" id="leftSelectButton">select button</button></div>
-          <div><button class="trigger-button" id="leftSqueezeButton">squeeze button</button></div>
-        </div>
-      </div>
     </div>
     <script src="three/three.js"></script>
     <script src="three/GLTFLoader.js"></script>
@@ -189,6 +184,8 @@
     <script src="three/OrbitControls.js"></script>
     <script src="three/TransformControls.js"></script>
     <script src="../ConfigurationManager.js"></script>
+    <script src="../lib/InputProfiles.js"></script>
+    <script src="../lib/joystick.js"></script>
     <script src="panel.js"></script>
   </body>
 </html>

--- a/src/devices.json
+++ b/src/devices.json
@@ -1,6 +1,6 @@
 {
   "default": {
-    "deviceKey": "Oculus Go",
+    "deviceKey": "Oculus Quest",
     "stereoEffect": true
   },
   "devices": {
@@ -26,6 +26,7 @@
     "HTC Vive": {
       "id": "HTC Vive",
       "name": "HTC Vive",
+      "profile": "htc-vive",
       "modes": [
         "inline",
         "immersive-vr"
@@ -42,7 +43,8 @@
           "primarySqueezeButtonIndex": 1,
           "hasPosition": true,
           "hasRotation": true,
-          "hasSqueezeButton": true
+          "hasSqueezeButton": true,
+          "handedness": "right"
         },
         {
           "id": "OpenVR Gamepad",
@@ -51,13 +53,18 @@
           "primarySqueezeButtonIndex": 1,
           "hasPosition": true,
           "hasRotation": true,
-          "hasSqueezeButton": true
+          "hasSqueezeButton": true,
+          "handedness": "left"
         }
-      ]
+      ],
+      "polyfillInputMapping": {
+        "buttons": [1, 2, 0]
+      }
     },
     "Oculus Go": {
       "id": "Oculus Go",
       "name": "Oculus Go",
+      "profile": "oculus-go",
       "modes": [
         "inline",
         "immersive-vr"
@@ -73,13 +80,18 @@
           "primaryButtonIndex": 0,
           "hasPosition": false,
           "hasRotation": true,
-          "hasSqueezeButton": false
+          "hasSqueezeButton": false,
+          "handedness": "right"
         }
-      ]
+      ],
+      "polyfillInputMapping": {
+        "buttons": [1, null, 0]
+      }
     },
-    "Oculus Quest": {
-      "id": "Oculus Quest",
-      "name": "Oculus Quest",
+    "Oculus Rift CV1": {
+      "id": "Oculus Rift CV1",
+      "name": "Oculus Rift CV1",
+      "profile": "oculus-touch",
       "modes": [
         "inline",
         "immersive-vr"
@@ -96,7 +108,8 @@
           "primarySqueezeButtonIndex": 1,
           "hasPosition": true,
           "hasRotation": true,
-          "hasSqueezeButton": true
+          "hasSqueezeButton": true,
+          "handedness": "right"
         },
         {
           "id": "Oculus Touch (Left)",
@@ -105,9 +118,131 @@
           "primarySqueezeButtonIndex": 1,
           "hasPosition": true,
           "hasRotation": true,
-          "hasSqueezeButton": true
+          "hasSqueezeButton": true,
+          "handedness": "left"
         }
-      ]
+      ],
+      "polyfillInputMapping": {
+        "axes": [2, 3, 0, 1],
+        "buttons": [1, 2, null, 0, 3, 4, null]
+      }
+    },
+    "Oculus Rift S": {
+      "id": "Oculus Rift S",
+      "name": "Oculus Rift S",
+      "profile": "oculus-touch-v2",
+      "modes": [
+        "inline",
+        "immersive-vr"
+      ],
+      "headset": {
+        "hasPosition": true,
+        "hasRotation": true
+      },
+      "controllers": [
+        {
+          "id": "Oculus Touch V2 (Right)",
+          "buttonNum": 7,
+          "primaryButtonIndex": 0,
+          "primarySqueezeButtonIndex": 1,
+          "hasPosition": true,
+          "hasRotation": true,
+          "hasSqueezeButton": true,
+          "handedness": "right"
+        },
+        {
+          "id": "Oculus Touch V2 (Left)",
+          "buttonNum": 7,
+          "primaryButtonIndex": 0,
+          "primarySqueezeButtonIndex": 1,
+          "hasPosition": true,
+          "hasRotation": true,
+          "hasSqueezeButton": true,
+          "handedness": "left"
+        }
+      ],
+      "polyfillInputMapping": {
+        "axes": [2, 3, 0, 1],
+        "buttons": [1, 2, null, 0, 3, 4, null]
+      }
+    },
+    "Oculus Quest": {
+      "id": "Oculus Quest",
+      "name": "Oculus Quest",
+      "profile": "oculus-touch-v2",
+      "modes": [
+        "inline",
+        "immersive-vr"
+      ],
+      "headset": {
+        "hasPosition": true,
+        "hasRotation": true
+      },
+      "controllers": [
+        {
+          "id": "Oculus Touch V2 (Right)",
+          "buttonNum": 7,
+          "primaryButtonIndex": 0,
+          "primarySqueezeButtonIndex": 1,
+          "hasPosition": true,
+          "hasRotation": true,
+          "hasSqueezeButton": true,
+          "handedness": "right"
+        },
+        {
+          "id": "Oculus Touch V2 (Left)",
+          "buttonNum": 7,
+          "primaryButtonIndex": 0,
+          "primarySqueezeButtonIndex": 1,
+          "hasPosition": true,
+          "hasRotation": true,
+          "hasSqueezeButton": true,
+          "handedness": "left"
+        }
+      ],
+      "polyfillInputMapping": {
+        "axes": [2, 3, 0, 1],
+        "buttons": [1, 2, null, 0, 3, 4, null]
+      }
+    },
+    "Oculus Quest 2": {
+      "id": "Oculus Quest 2",
+      "name": "Oculus Quest 2",
+      "profile": "oculus-touch-v3",
+      "modes": [
+        "inline",
+        "immersive-vr"
+      ],
+      "headset": {
+        "hasPosition": true,
+        "hasRotation": true
+      },
+      "controllers": [
+        {
+          "id": "Oculus Touch V3 (Right)",
+          "buttonNum": 7,
+          "primaryButtonIndex": 0,
+          "primarySqueezeButtonIndex": 1,
+          "hasPosition": true,
+          "hasRotation": true,
+          "hasSqueezeButton": true,
+          "handedness": "right"
+        },
+        {
+          "id": "Oculus Touch V3 (Left)",
+          "buttonNum": 7,
+          "primaryButtonIndex": 0,
+          "primarySqueezeButtonIndex": 1,
+          "hasPosition": true,
+          "hasRotation": true,
+          "hasSqueezeButton": true,
+          "handedness": "left"
+        }
+      ],
+      "polyfillInputMapping": {
+        "axes": [2, 3, 0, 1],
+        "buttons": [1, 2, null, 0, 3, 4, null]
+      }
     },
     "Samsung Galaxy S8+ (AR)": {
       "id": "Samsung Galaxy S8+ (AR)",
@@ -150,6 +285,7 @@
     "Samsung Gear VR": {
       "id": "Samsung Gear VR",
       "name": "Samsung Gear VR",
+      "profile": "samsung-gearvr",
       "modes": [
         "inline",
         "immersive-vr"
@@ -164,9 +300,13 @@
           "buttonNum": 3,
           "primaryButtonIndex": 0,
           "hasPosition": false,
-          "hasRotation": true
+          "hasRotation": true,
+          "handedness": "right"
         }
-      ]
+      ],
+      "polyfillInputMapping": {
+        "buttons": [1, null, 0]
+      }
     }
   }
 }

--- a/src/extension/content-script.js
+++ b/src/extension/content-script.js
@@ -40,6 +40,14 @@ port.onMessage.addListener(message => {
       });
       break;
 
+    case 'webxr-input-axis':
+      dispatchCustomEvent('webxr-input-axis', {
+        objectName: message.objectName,
+        value: message.value,
+        axisIndex: message.axisIndex
+      });
+      break;
+
     case 'webxr-stereo-effect':
       dispatchCustomEvent('webxr-stereo-effect', {
         enabled: message.enabled

--- a/src/lib/InputProfiles.js
+++ b/src/lib/InputProfiles.js
@@ -1,0 +1,396 @@
+/**
+ * @webxr-input-profiles/motion-controllers 1.0.0 https://github.com/immersive-web/webxr-input-profiles
+ */
+
+ const Constants = {
+  Handedness: Object.freeze({
+    NONE: 'none',
+    LEFT: 'left',
+    RIGHT: 'right'
+  }),
+
+  ComponentState: Object.freeze({
+    DEFAULT: 'default',
+    TOUCHED: 'touched',
+    PRESSED: 'pressed'
+  }),
+
+  ComponentProperty: Object.freeze({
+    BUTTON: 'button',
+    X_AXIS: 'xAxis',
+    Y_AXIS: 'yAxis',
+    STATE: 'state'
+  }),
+
+  ComponentType: Object.freeze({
+    TRIGGER: 'trigger',
+    SQUEEZE: 'squeeze',
+    TOUCHPAD: 'touchpad',
+    THUMBSTICK: 'thumbstick',
+    BUTTON: 'button'
+  }),
+
+  ButtonTouchThreshold: 0.05,
+
+  AxisTouchThreshold: 0.1,
+
+  VisualResponseProperty: Object.freeze({
+    TRANSFORM: 'transform',
+    VISIBILITY: 'visibility'
+  })
+};
+
+/**
+ * @description Static helper function to fetch a JSON file and turn it into a JS object
+ * @param {string} path - Path to JSON file to be fetched
+ */
+async function fetchJsonFile(path) {
+  const response = await fetch(path);
+  if (!response.ok) {
+    throw new Error(response.statusText);
+  } else {
+    return response.json();
+  }
+}
+
+async function fetchProfilesList(basePath) {
+  if (!basePath) {
+    throw new Error('No basePath supplied');
+  }
+
+  const profileListFileName = 'profilesList.json';
+  const profilesList = await fetchJsonFile(`${basePath}/${profileListFileName}`);
+  return profilesList;
+}
+
+async function fetchProfile(xrInputSource, basePath, defaultProfile = null, getAssetPath = true) {
+  if (!xrInputSource) {
+    throw new Error('No xrInputSource supplied');
+  }
+
+  if (!basePath) {
+    throw new Error('No basePath supplied');
+  }
+
+  // Get the list of profiles
+  const supportedProfilesList = await fetchProfilesList(basePath);
+
+  // Find the relative path to the first requested profile that is recognized
+  let match;
+  xrInputSource.profiles.some((profileId) => {
+    const supportedProfile = supportedProfilesList[profileId];
+    if (supportedProfile) {
+      match = {
+        profileId,
+        profilePath: `${basePath}/${supportedProfile.path}`,
+        deprecated: !!supportedProfile.deprecated
+      };
+    }
+    return !!match;
+  });
+
+  if (!match) {
+    if (!defaultProfile) {
+      throw new Error('No matching profile name found');
+    }
+
+    const supportedProfile = supportedProfilesList[defaultProfile];
+    if (!supportedProfile) {
+      throw new Error(`No matching profile name found and default profile "${defaultProfile}" missing.`);
+    }
+
+    match = {
+      profileId: defaultProfile,
+      profilePath: `${basePath}/${supportedProfile.path}`,
+      deprecated: !!supportedProfile.deprecated
+    };
+  }
+
+  const profile = await fetchJsonFile(match.profilePath);
+
+  let assetPath;
+  if (getAssetPath) {
+    let layout;
+    if (xrInputSource.handedness === 'any') {
+      layout = profile.layouts[Object.keys(profile.layouts)[0]];
+    } else {
+      console.log(profile.layouts, xrInputSource.handedness);
+      layout = profile.layouts[xrInputSource.handedness];
+    }
+    if (!layout) {
+      throw new Error(
+        `No matching handedness, ${xrInputSource.handedness}, in profile ${match.profileId}`
+      );
+    }
+
+    if (layout.assetPath) {
+      assetPath = match.profilePath.replace('profile.json', layout.assetPath);
+    }
+  }
+
+  return { profile, assetPath };
+}
+
+/** @constant {Object} */
+const defaultComponentValues = {
+  xAxis: 0,
+  yAxis: 0,
+  button: 0,
+  state: Constants.ComponentState.DEFAULT
+};
+
+/**
+ * @description Converts an X, Y coordinate from the range -1 to 1 (as reported by the Gamepad
+ * API) to the range 0 to 1 (for interpolation). Also caps the X, Y values to be bounded within
+ * a circle. This ensures that thumbsticks are not animated outside the bounds of their physical
+ * range of motion and touchpads do not report touch locations off their physical bounds.
+ * @param {number} x The original x coordinate in the range -1 to 1
+ * @param {number} y The original y coordinate in the range -1 to 1
+ */
+function normalizeAxes(x = 0, y = 0) {
+  let xAxis = x;
+  let yAxis = y;
+
+  // Determine if the point is outside the bounds of the circle
+  // and, if so, place it on the edge of the circle
+  const hypotenuse = Math.sqrt((x * x) + (y * y));
+  if (hypotenuse > 1) {
+    const theta = Math.atan2(y, x);
+    xAxis = Math.cos(theta);
+    yAxis = Math.sin(theta);
+  }
+
+  // Scale and move the circle so values are in the interpolation range.  The circle's origin moves
+  // from (0, 0) to (0.5, 0.5). The circle's radius scales from 1 to be 0.5.
+  const result = {
+    normalizedXAxis: (xAxis * 0.5) + 0.5,
+    normalizedYAxis: (yAxis * 0.5) + 0.5
+  };
+  return result;
+}
+
+/**
+ * Contains the description of how the 3D model should visually respond to a specific user input.
+ * This is accomplished by initializing the object with the name of a node in the 3D model and
+ * property that need to be modified in response to user input, the name of the nodes representing
+ * the allowable range of motion, and the name of the input which triggers the change. In response
+ * to the named input changing, this object computes the appropriate weighting to use for
+ * interpolating between the range of motion nodes.
+ */
+class VisualResponse {
+  constructor(visualResponseDescription) {
+    this.componentProperty = visualResponseDescription.componentProperty;
+    this.states = visualResponseDescription.states;
+    this.valueNodeName = visualResponseDescription.valueNodeName;
+    this.valueNodeProperty = visualResponseDescription.valueNodeProperty;
+
+    if (this.valueNodeProperty === Constants.VisualResponseProperty.TRANSFORM) {
+      this.minNodeName = visualResponseDescription.minNodeName;
+      this.maxNodeName = visualResponseDescription.maxNodeName;
+    }
+
+    // Initializes the response's current value based on default data
+    this.value = 0;
+    this.updateFromComponent(defaultComponentValues);
+  }
+
+  /**
+   * Computes the visual response's interpolation weight based on component state
+   * @param {Object} componentValues - The component from which to update
+   * @param {number} xAxis - The reported X axis value of the component
+   * @param {number} yAxis - The reported Y axis value of the component
+   * @param {number} button - The reported value of the component's button
+   * @param {string} state - The component's active state
+   */
+  updateFromComponent({
+    xAxis, yAxis, button, state
+  }) {
+    const { normalizedXAxis, normalizedYAxis } = normalizeAxes(xAxis, yAxis);
+    switch (this.componentProperty) {
+      case Constants.ComponentProperty.X_AXIS:
+        this.value = (this.states.includes(state)) ? normalizedXAxis : 0.5;
+        break;
+      case Constants.ComponentProperty.Y_AXIS:
+        this.value = (this.states.includes(state)) ? normalizedYAxis : 0.5;
+        break;
+      case Constants.ComponentProperty.BUTTON:
+        this.value = (this.states.includes(state)) ? button : 0;
+        break;
+      case Constants.ComponentProperty.STATE:
+        if (this.valueNodeProperty === Constants.VisualResponseProperty.VISIBILITY) {
+          this.value = (this.states.includes(state));
+        } else {
+          this.value = this.states.includes(state) ? 1.0 : 0.0;
+        }
+        break;
+      default:
+        throw new Error(`Unexpected visualResponse componentProperty ${this.componentProperty}`);
+    }
+  }
+}
+
+class Component {
+  /**
+   * @param {Object} componentId - Id of the component
+   * @param {Object} componentDescription - Description of the component to be created
+   */
+  constructor(componentId, componentDescription) {
+    if (!componentId
+     || !componentDescription
+     || !componentDescription.visualResponses
+     || !componentDescription.gamepadIndices
+     || Object.keys(componentDescription.gamepadIndices).length === 0) {
+      throw new Error('Invalid arguments supplied');
+    }
+
+    this.id = componentId;
+    this.type = componentDescription.type;
+    this.rootNodeName = componentDescription.rootNodeName;
+    this.touchPointNodeName = componentDescription.touchPointNodeName;
+
+    // Build all the visual responses for this component
+    this.visualResponses = {};
+    Object.keys(componentDescription.visualResponses).forEach((responseName) => {
+      const visualResponse = new VisualResponse(componentDescription.visualResponses[responseName]);
+      this.visualResponses[responseName] = visualResponse;
+    });
+
+    // Set default values
+    this.gamepadIndices = Object.assign({}, componentDescription.gamepadIndices);
+
+    this.values = {
+      state: Constants.ComponentState.DEFAULT,
+      button: (this.gamepadIndices.button !== undefined) ? 0 : undefined,
+      xAxis: (this.gamepadIndices.xAxis !== undefined) ? 0 : undefined,
+      yAxis: (this.gamepadIndices.yAxis !== undefined) ? 0 : undefined
+    };
+  }
+
+  get data() {
+    const data = { id: this.id, ...this.values };
+    return data;
+  }
+
+  /**
+   * @description Poll for updated data based on current gamepad state
+   * @param {Object} gamepad - The gamepad object from which the component data should be polled
+   */
+  updateFromGamepad(gamepad) {
+    // Set the state to default before processing other data sources
+    this.values.state = Constants.ComponentState.DEFAULT;
+
+    // Get and normalize button
+    if (this.gamepadIndices.button !== undefined
+        && gamepad.buttons.length > this.gamepadIndices.button) {
+      const gamepadButton = gamepad.buttons[this.gamepadIndices.button];
+      this.values.button = gamepadButton.value;
+      this.values.button = (this.values.button < 0) ? 0 : this.values.button;
+      this.values.button = (this.values.button > 1) ? 1 : this.values.button;
+
+      // Set the state based on the button
+      if (gamepadButton.pressed || this.values.button === 1) {
+        this.values.state = Constants.ComponentState.PRESSED;
+      } else if (gamepadButton.touched || this.values.button > Constants.ButtonTouchThreshold) {
+        this.values.state = Constants.ComponentState.TOUCHED;
+      }
+    }
+
+    // Get and normalize x axis value
+    if (this.gamepadIndices.xAxis !== undefined
+        && gamepad.axes.length > this.gamepadIndices.xAxis) {
+      this.values.xAxis = gamepad.axes[this.gamepadIndices.xAxis];
+      this.values.xAxis = (this.values.xAxis < -1) ? -1 : this.values.xAxis;
+      this.values.xAxis = (this.values.xAxis > 1) ? 1 : this.values.xAxis;
+
+      // If the state is still default, check if the xAxis makes it touched
+      if (this.values.state === Constants.ComponentState.DEFAULT
+        && Math.abs(this.values.xAxis) > Constants.AxisTouchThreshold) {
+        this.values.state = Constants.ComponentState.TOUCHED;
+      }
+    }
+
+    // Get and normalize Y axis value
+    if (this.gamepadIndices.yAxis !== undefined
+        && gamepad.axes.length > this.gamepadIndices.yAxis) {
+      this.values.yAxis = gamepad.axes[this.gamepadIndices.yAxis];
+      this.values.yAxis = (this.values.yAxis < -1) ? -1 : this.values.yAxis;
+      this.values.yAxis = (this.values.yAxis > 1) ? 1 : this.values.yAxis;
+
+      // If the state is still default, check if the yAxis makes it touched
+      if (this.values.state === Constants.ComponentState.DEFAULT
+        && Math.abs(this.values.yAxis) > Constants.AxisTouchThreshold) {
+        this.values.state = Constants.ComponentState.TOUCHED;
+      }
+    }
+
+    // Update the visual response weights based on the current component data
+    Object.values(this.visualResponses).forEach((visualResponse) => {
+      visualResponse.updateFromComponent(this.values);
+    });
+  }
+}
+
+/**
+  * @description Builds a motion controller with components and visual responses based on the
+  * supplied profile description. Data is polled from the xrInputSource's gamepad.
+  * @author Nell Waliczek / https://github.com/NellWaliczek
+*/
+class MotionController {
+  /**
+   * @param {Object} xrInputSource - The XRInputSource to build the MotionController around
+   * @param {Object} profile - The best matched profile description for the supplied xrInputSource
+   * @param {Object} assetUrl
+   */
+  constructor(xrInputSource, profile, assetUrl) {
+    if (!xrInputSource) {
+      throw new Error('No xrInputSource supplied');
+    }
+
+    if (!profile) {
+      throw new Error('No profile supplied');
+    }
+
+    this.xrInputSource = xrInputSource;
+    this.assetUrl = assetUrl;
+    this.id = profile.profileId;
+
+    // Build child components as described in the profile description
+    this.layoutDescription = profile.layouts[xrInputSource.handedness];
+    this.components = {};
+    Object.keys(this.layoutDescription.components).forEach((componentId) => {
+      const componentDescription = this.layoutDescription.components[componentId];
+      this.components[componentId] = new Component(componentId, componentDescription);
+    });
+
+    // Initialize components based on current gamepad state
+    this.updateFromGamepad();
+  }
+
+  get gripSpace() {
+    return this.xrInputSource.gripSpace;
+  }
+
+  get targetRaySpace() {
+    return this.xrInputSource.targetRaySpace;
+  }
+
+  /**
+   * @description Returns a subset of component data for simplified debugging
+   */
+  get data() {
+    const data = [];
+    Object.values(this.components).forEach((component) => {
+      data.push(component.data);
+    });
+    return data;
+  }
+
+  /**
+   * @description Poll for updated data based on current gamepad state
+   */
+  updateFromGamepad() {
+    Object.values(this.components).forEach((component) => {
+      component.updateFromGamepad(this.xrInputSource.gamepad);
+    });
+  }
+}

--- a/src/lib/joystick.js
+++ b/src/lib/joystick.js
@@ -1,0 +1,117 @@
+const CIRCUMFERENCE = 2 * Math.PI;
+const LINEWIDTH = 1;
+const OUTER_STROKE_COLOR = "#000000";
+const INNER_STROKE_COLOR = "#000000";
+const INNER_FILL_COLOR = "#A9A9A9";
+
+class Joystick {
+  constructor(radius, autoReturn){
+    this._radius = radius;
+    this._autoReturn = autoReturn;
+    
+    let canvas = document.createElement("canvas");
+    canvas.id = 'Joystick';
+    canvas.width = radius;
+    canvas.height = radius;
+    this._canvas = canvas;
+    
+    this._pressed = false;
+    this._innerRadius = radius/6;
+    this._outerRadius = radius/3;
+    this._maxStickDelta = this._outerRadius;
+
+    this._centerX = radius/2;
+    this._centerY = radius/2;
+    this._deltaX = 0;
+    this._deltaY = 0;
+
+    canvas.addEventListener("mousedown", this._onMouseDown.bind(this), false);
+    document.addEventListener("mousemove", this._onMouseMove.bind(this), false);
+    document.addEventListener("mouseup", this._onMouseUp.bind(this), false);
+
+    this._drawOuterCircle();
+    this._drawInnerCircle();
+
+  }
+
+  _drawOuterCircle() {
+    let context = this._canvas.getContext('2d');
+    context.beginPath();
+    context.arc(this._centerX, this._centerY, this._outerRadius, 0, CIRCUMFERENCE, false);
+
+    context.lineWidth = LINEWIDTH;
+    context.strokeStyle = OUTER_STROKE_COLOR;
+    context.stroke();
+  }
+
+  _drawInnerCircle() {
+    let context = this._canvas.getContext('2d');
+    context.beginPath();
+    let deltaDistance = Math.sqrt(this._deltaX * this._deltaX + this._deltaY * this._deltaY);
+    let scaleFactor = deltaDistance / this._maxStickDelta;
+    if (scaleFactor > 1) {
+      this._deltaX /= scaleFactor;
+      this._deltaY /= scaleFactor;
+    }
+    context.arc(this._deltaX + this._centerX, this._deltaY + this._centerY, this._innerRadius, 0, CIRCUMFERENCE, false);
+
+    context.fillStyle = INNER_FILL_COLOR;
+    context.fill();
+    context.lineWidth = LINEWIDTH;
+    context.strokeStyle = INNER_STROKE_COLOR;
+    context.stroke();
+  }
+
+  _onMouseDown(_event) {
+    this._pressed = true;
+  }
+
+  _onMouseUp(_event) {
+    let context = this._canvas.getContext('2d');
+    this._pressed = false;
+
+    if (this._autoReturn) {
+      this._deltaX = 0;
+      this._deltaY = 0;
+    }
+    
+    context.clearRect(0, 0, this._canvas.width, this._canvas.height);
+    
+    this._drawOuterCircle();
+    this._drawInnerCircle();
+  }
+
+  _onMouseMove(event) {
+    if (this._pressed) {
+      let context = this._canvas.getContext('2d');
+      this._deltaX = event.pageX-this._centerX;
+      this._deltaY = event.pageY-this._centerY;
+      
+      if (this._canvas.offsetParent.tagName.toUpperCase() === "BODY") {
+        this._deltaX -= this._canvas.offsetLeft;
+        this._deltaY -= this._canvas.offsetTop;
+      } else {
+        this._deltaX -= this._canvas.offsetParent.offsetLeft;
+        this._deltaY -= this._canvas.offsetParent.offsetTop;
+      }
+      
+      context.clearRect(0, 0, this._canvas.width, this._canvas.height);
+      
+      this._drawOuterCircle();
+      this._drawInnerCircle();
+    }
+  }
+
+  addToParent(parent) {
+    parent.appendChild(this._canvas);
+  }
+
+  getX() {
+    return (100 * (this._deltaX / this._maxStickDelta)).toFixed()/100;
+  }
+
+  getY() {
+    return (100 * (this._deltaY / this._maxStickDelta)).toFixed()/100;
+  }
+
+}

--- a/src/polyfill/EmulatedXRDevice.js
+++ b/src/polyfill/EmulatedXRDevice.js
@@ -741,6 +741,13 @@ export default class EmulatedXRDevice extends XRDevice {
     gamepad.buttons[buttonIndex].value = pressed ? 1.0 : 0.0;
   }
 
+  _updateInputAxisValue(value, controllerIndex, axisIndex) {
+    if (controllerIndex >= this.gamepads.length) { return; }
+    const gamepad = this.gamepads[controllerIndex];
+    if (axisIndex >= gamepad.axes.length) { return; }
+    gamepad.axes[axisIndex] = value;
+  }
+
   _updateInputAxes(controllerIndex, x, y) {
     if (controllerIndex >= this.gamepads.length) { return; }
     const gamepad = this.gamepads[controllerIndex];
@@ -865,6 +872,25 @@ export default class EmulatedXRDevice extends XRDevice {
           this._updateInputButtonPressed(pressed,
             objectName === 'rightController' ? 0 : 1, // @TODO: remove magic number
             buttonIndex);
+          break;
+      }
+    }, false);
+
+    window.addEventListener('webxr-input-axis', event => {
+      if (this.arDevice) {
+        return;
+      }
+
+      const value = event.detail.value;
+      const objectName = event.detail.objectName;
+      const axisIndex = event.detail.axisIndex;
+
+      switch (objectName) {
+        case 'rightController':
+        case 'leftController':
+          this._updateInputAxisValue(value,
+            objectName === 'rightController' ? 0 : 1, // @TODO: remove magic number
+            axisIndex);
           break;
       }
     }, false);


### PR DESCRIPTION
This PR makes the following changes:
1. Fixed incorrect button mapping for Oculus Quest and HTC Vive.
2. Add support for all buttons on oculus devices. Instead of hard code the buttons for all headsets in devices.json, load the input configuration from [WebXR Input Profile](https://github.com/immersive-web/webxr-input-profiles), and auto generate buttons accordingly. This change is not unique to oculus devices, by adding the proper input configuration to WebXR Input Profiles and correct input mapping to WebXR Polyfill, the added inputs will automatically appear for the device. The same has been done to HTC Vive.
3. Add joystick UI for headsets that implements xr-standard-thumbstick (oculus headsets, windows mixed reality devices, htc vive, etc.)
4. Update webxr-polyfill to update and add support for new oculus headsets, fixing the issue where selecting oculus quest headset makes the emulator give incorrect profile name (oculus-touch instead of oculus-touch-v2), adding support for quest 2 and oculus rift s. The PR to webxr-polyfill can be found [here](https://github.com/immersive-web/webxr-polyfill/pull/163) When this is merged, I will update the dependency source in package.json

Please refer to this quick demo for the changes:

https://user-images.githubusercontent.com/11973041/141720218-328c49a1-9ccd-4b6d-a1c7-d7d29e10598a.mov