### PR TITLE
Adding support for srcDoc (dynamic) IFrames

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -27,6 +27,7 @@
       "http://*/*",
       "https://*/*"
     ],
+    "match_about_blank": true,
     "js": [
       "polyfill/webxr-polyfill.js",
       "src/ConfigurationManager.js",


### PR DESCRIPTION
The current WebXR-emulator does not support "srcDoc" (dynamic) Iframes.  This change will allow users who use Iframes created from "srcDoc"(s) to use the WebXR-emulator. 

Tested with Chrome and Firefox.