### PR TITLE
workaround zoom

### DIFF
--- a/polyfill/webxr-polyfill.js
+++ b/polyfill/webxr-polyfill.js
@@ -103,7 +103,7 @@ function WebXRPolyfillInjection() {
                   out[7] = 0;
                   out[8] = 0;
                   out[9] = 0;
-                  out[10] = 1;
+                  out[10] = 2;
                   out[11] = 0;
                   out[12] = 0;
                   out[13] = 0;


### PR DESCRIPTION
Since control emulation is not implemented, this work-around zooms out to show the full scene. 